### PR TITLE
Display application information in settings page

### DIFF
--- a/doc/dependency-graph.md
+++ b/doc/dependency-graph.md
@@ -19,6 +19,7 @@ graph LR
                     src_lib_application_usecases_deleteEpisode_ts["deleteEpisode.ts"]
                     src_lib_application_usecases_deleteGroupRecursive_ts["deleteGroupRecursive.ts"]
                     src_lib_application_usecases_fetchAlbumGroups_ts["fetchAlbumGroups.ts"]
+                    src_lib_application_usecases_fetchAppInfo_ts["fetchAppInfo.ts"]
                     src_lib_application_usecases_fetchAvailableParentGroups_ts["fetchAvailableParentGroups.ts"]
                     src_lib_application_usecases_fetchEpisodeDetail_ts["fetchEpisodeDetail.ts"]
                     src_lib_application_usecases_fetchEpisodeGroups_ts["fetchEpisodeGroups.ts"]
@@ -36,6 +37,7 @@ graph LR
             end
             subgraph "domain"
                 subgraph "entities"
+                    src_lib_domain_entities_appInfo_ts["appInfo.ts"]
                     src_lib_domain_entities_dialogue_ts["dialogue.ts"]
                     src_lib_domain_entities_episode_ts["episode.ts"]
                     src_lib_domain_entities_episodeGroup_ts["episodeGroup.ts"]
@@ -54,6 +56,7 @@ graph LR
                 src_lib_infrastructure_config_ts["config.ts"]
                 subgraph "repositories"
                     src_lib_infrastructure_repositories_apiKeyRepository_ts["apiKeyRepository.ts"]
+                    src_lib_infrastructure_repositories_appInfoRepository_ts["appInfoRepository.ts"]
                     src_lib_infrastructure_repositories_dialogueRepository_ts["dialogueRepository.ts"]
                     src_lib_infrastructure_repositories_episodeGroupRepository_ts["episodeGroupRepository.ts"]
                     src_lib_infrastructure_repositories_episodeRepository_ts["episodeRepository.ts"]
@@ -143,6 +146,8 @@ src_lib_application_usecases_deleteGroupRecursive_ts --> src_lib_infrastructure_
 src_lib_application_usecases_deleteGroupRecursive_ts --> src_lib_infrastructure_repositories_episodeRepository_ts
 src_lib_application_usecases_fetchAlbumGroups_ts --> src_lib_domain_services_buildEpisodeGroupTree_ts
 src_lib_application_usecases_fetchAlbumGroups_ts --> src_lib_infrastructure_repositories_episodeGroupRepository_ts
+src_lib_application_usecases_fetchAppInfo_ts --> src_lib_domain_entities_appInfo_ts
+src_lib_application_usecases_fetchAppInfo_ts --> src_lib_infrastructure_repositories_appInfoRepository_ts
 src_lib_application_usecases_fetchAvailableParentGroups_ts --> src_lib_domain_entities_episodeGroup_ts
 src_lib_application_usecases_fetchAvailableParentGroups_ts --> src_lib_domain_services_buildEpisodeGroupTree_ts
 src_lib_application_usecases_fetchAvailableParentGroups_ts --> src_lib_domain_services_groupTreeHelper_ts
@@ -186,6 +191,7 @@ src_lib_domain_entities_sentenceAnalysisResult_ts --> src_lib_domain_entities_se
 src_lib_domain_services_buildEpisodeGroupTree_ts --> src_lib_domain_entities_episodeGroup_ts
 src_lib_domain_services_groupTreeHelper_ts --> src_lib_domain_entities_episodeGroup_ts
 src_lib_domain_services_parseSrtToDialogues_ts --> src_lib_domain_entities_dialogue_ts
+src_lib_infrastructure_repositories_appInfoRepository_ts --> src_lib_domain_entities_appInfo_ts
 src_lib_infrastructure_repositories_dialogueRepository_ts --> src_lib_domain_entities_dialogue_ts
 src_lib_infrastructure_repositories_dialogueRepository_ts --> src_lib_infrastructure_config_ts
 src_lib_infrastructure_repositories_episodeGroupRepository_ts --> src_lib_domain_entities_episodeGroup_ts
@@ -274,5 +280,6 @@ src_routes_episode__id___page_ts --> src_lib_application_usecases_fetchEpisodeDe
 src_routes_episode__id___page_ts --> src_lib_application_usecases_fetchSettings_ts
 src_routes_settings__page_svelte --> src_lib_application_stores_i18n_svelte_ts
 src_routes_settings__page_svelte --> src_lib_application_usecases_saveSettings_ts
+src_routes_settings__page_ts --> src_lib_application_usecases_fetchAppInfo_ts
 src_routes_settings__page_ts --> src_lib_application_usecases_fetchSettings_ts
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kotonoha",
   "version": "0.1.0",
-  "description": "An app that automates sentence mining for immersive learning.",
+  "description": "An app for language learning, centered around AI-powered sentence mining.",
   "author": "Keigo Nakatani <k5n@users.noreply.github.com> (https://github.com/k5n)",
   "license": "GPL-3.0-only",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2848,7 +2848,7 @@ dependencies = [
 
 [[package]]
 name = "kotonoha"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "dotenvy",
  "google-ai-rs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "kotonoha"
 # The version is managed centrally in package.json
-description = "An app that automates sentence mining for immersive learning."
-authors = ["Keigo Nakatani <k5n@users.noreply.github.com> (https://github.com/k5n)"]
-license = "GNU General Public License v3.0"
+# The same goes for description, license, and authors.
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kotonoha"
-version = "0.1.0"
+# The version is managed centrally in package.json
 description = "An app that automates sentence mining for immersive learning."
 authors = ["Keigo Nakatani <k5n@users.noreply.github.com> (https://github.com/k5n)"]
 license = "GNU General Public License v3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kotonoha",
-  "version": "0.1.0",
+  "version": "../package.json",
   "identifier": "com.k5-n.kotonoha.mining",
   "build": {
     "beforeDevCommand": "npx vite dev",

--- a/src/lib/application/usecases/fetchAppInfo.ts
+++ b/src/lib/application/usecases/fetchAppInfo.ts
@@ -1,0 +1,6 @@
+import type { AppInfo } from '$lib/domain/entities/appInfo';
+import { appInfoRepository } from '$lib/infrastructure/repositories/appInfoRepository';
+
+export async function fetchAppInfo(): Promise<AppInfo> {
+  return appInfoRepository.getAppInfo();
+}

--- a/src/lib/domain/entities/appInfo.ts
+++ b/src/lib/domain/entities/appInfo.ts
@@ -1,0 +1,3 @@
+export type AppInfo = {
+  readonly appVersion: string;
+};

--- a/src/lib/domain/entities/appInfo.ts
+++ b/src/lib/domain/entities/appInfo.ts
@@ -1,3 +1,7 @@
 export type AppInfo = {
-  readonly appVersion: string;
+  readonly name: string;
+  readonly version: string;
+  readonly copyright: string;
+  readonly license: string;
+  readonly homepage: string;
 };

--- a/src/lib/infrastructure/repositories/appInfoRepository.ts
+++ b/src/lib/infrastructure/repositories/appInfoRepository.ts
@@ -1,0 +1,11 @@
+import type { AppInfo } from '$lib/domain/entities/appInfo';
+import { getVersion } from '@tauri-apps/api/app';
+
+export const appInfoRepository = {
+  async getAppInfo(): Promise<AppInfo> {
+    const appVersion = await getVersion();
+    return {
+      appVersion,
+    };
+  },
+};

--- a/src/lib/infrastructure/repositories/appInfoRepository.ts
+++ b/src/lib/infrastructure/repositories/appInfoRepository.ts
@@ -1,11 +1,20 @@
 import type { AppInfo } from '$lib/domain/entities/appInfo';
 import { getVersion } from '@tauri-apps/api/app';
 
+const APP_NAME = 'Kotonoha';
+const APP_COPYRIGHT = 'Copyright (C) 2025  Keigo Nakatani (https://github.com/k5n)';
+const APP_LICENSE = 'GNU General Public License v3.0';
+const APP_HOMEPAGE = 'https://github.com/k5n/kotonoha';
+
 export const appInfoRepository = {
   async getAppInfo(): Promise<AppInfo> {
-    const appVersion = await getVersion();
+    const version = await getVersion();
     return {
-      appVersion,
+      name: APP_NAME,
+      version: version,
+      copyright: APP_COPYRIGHT,
+      license: APP_LICENSE,
+      homepage: APP_HOMEPAGE,
     };
   },
 };

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -25,6 +25,10 @@ export const en = {
         english: 'English',
         japanese: 'Japanese',
       },
+      appInfo: {
+        title: 'About Kotonoha',
+        version: 'Version',
+      },
     },
     groupPage: {
       title: 'Group List',

--- a/src/lib/locales/en.ts
+++ b/src/lib/locales/en.ts
@@ -1,5 +1,12 @@
 export const en = {
   translation: {
+    appInfo: {
+      title: 'About {{appName}}',
+      version: 'Version',
+      copyright: 'Copyright',
+      license: 'License',
+      homepage: 'Homepage',
+    },
     settings: {
       title: 'Settings',
       backButton: 'Back',
@@ -24,10 +31,6 @@ export const en = {
         label: 'Language',
         english: 'English',
         japanese: 'Japanese',
-      },
-      appInfo: {
-        title: 'About Kotonoha',
-        version: 'Version',
       },
     },
     groupPage: {

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -25,6 +25,10 @@ export const ja = {
         english: '英語',
         japanese: '日本語',
       },
+      appInfo: {
+        title: 'Kotonohaについて',
+        version: 'バージョン',
+      },
     },
     groupPage: {
       title: 'グループ一覧',

--- a/src/lib/locales/ja.ts
+++ b/src/lib/locales/ja.ts
@@ -1,5 +1,12 @@
 export const ja = {
   translation: {
+    appInfo: {
+      title: '{{appName}}について',
+      version: 'バージョン',
+      copyright: '著作権',
+      license: 'ライセンス',
+      homepage: 'ホームページ',
+    },
     settings: {
       title: '設定',
       backButton: '戻る',
@@ -24,10 +31,6 @@ export const ja = {
         label: '言語',
         english: '英語',
         japanese: '日本語',
-      },
-      appInfo: {
-        title: 'Kotonohaについて',
-        version: 'バージョン',
       },
     },
     groupPage: {

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -126,9 +126,19 @@
 
   {#if appInfo}
     <div class="mt-8 border-t border-gray-200 pt-4">
-      <h2 class="mb-2 text-lg font-semibold">{t('settings.appInfo.title')}</h2>
-      <div class="text-sm text-gray-500">
-        {t('settings.appInfo.version')}: {appInfo.appVersion}
+      <h2 class="mb-2 text-lg font-semibold">
+        {t('appInfo.title', { appName: appInfo.name })}
+      </h2>
+      <div class="space-y-1 text-sm text-gray-500">
+        <div>{t('appInfo.version')}: {appInfo.version}</div>
+        <div>{t('appInfo.copyright')}: {appInfo.copyright}</div>
+        <div>{t('appInfo.license')}: {appInfo.license}</div>
+        <div>
+          {t('appInfo.homepage')}:
+          <a href={appInfo.homepage} target="_blank" rel="noopener" class="text-blue-600 underline"
+            >{appInfo.homepage}</a
+          >
+        </div>
       </div>
     </div>
   {/if}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -14,6 +14,7 @@
   let isSaving = $state(false);
 
   let settings = $derived(data.settings);
+  let appInfo = $derived(data.appInfo);
   let errorMessage = $derived(data.errorKey ? t(data.errorKey) : '');
 
   function goBack() {
@@ -121,5 +122,14 @@
     <Alert color="green" class="mt-4">
       {successMessage}
     </Alert>
+  {/if}
+
+  {#if appInfo}
+    <div class="mt-8 border-t border-gray-200 pt-4">
+      <h2 class="mb-2 text-lg font-semibold">{t('settings.appInfo.title')}</h2>
+      <div class="text-sm text-gray-500">
+        {t('settings.appInfo.version')}: {appInfo.appVersion}
+      </div>
+    </div>
   {/if}
 </div>

--- a/src/routes/settings/+page.ts
+++ b/src/routes/settings/+page.ts
@@ -1,3 +1,4 @@
+import { fetchAppInfo } from '$lib/application/usecases/fetchAppInfo';
 import { fetchSettings } from '$lib/application/usecases/fetchSettings';
 import { error } from '@tauri-apps/plugin-log';
 import type { PageLoad } from './$types';
@@ -5,9 +6,11 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async () => {
   try {
     const { isApiKeySet, settings } = await fetchSettings();
+    const appInfo = await fetchAppInfo();
     return {
       isApiKeySet,
       settings,
+      appInfo,
       errorKey: null,
     };
   } catch (e) {
@@ -15,6 +18,7 @@ export const load: PageLoad = async () => {
     return {
       isApiKeySet: false,
       settings: null,
+      appInfo: null,
       errorKey: 'settings.notifications.loadError',
     };
   }


### PR DESCRIPTION
This pull request updates the settings page to display the application's version.
In addition to the version, other relevant application details—such as name, copyright, license, and homepage—are also shown for reference.

- Labels for each field are localized in both English and Japanese. 
- The homepage is displayed as a clickable link.
