### PR TITLE
style: Make episode detail page responsive

### DIFF
--- a/src/lib/presentation/components/SentenceCardList.svelte
+++ b/src/lib/presentation/components/SentenceCardList.svelte
@@ -15,7 +15,7 @@
   }
 </script>
 
-<div class="space-y-2">
+<div class="space-y-2 lg:h-full lg:overflow-y-auto">
   {#if sentenceCards.length === 0}
     <div class="rounded-lg border-2 border-dashed py-10 text-center">
       <p class="text-gray-500">{t('components.sentenceCardList.noCards')}</p>

--- a/src/lib/presentation/components/TranscriptViewer.svelte
+++ b/src/lib/presentation/components/TranscriptViewer.svelte
@@ -56,9 +56,13 @@
 
 <div
   bind:this={containerEl}
-  class="h-[400px] space-y-1 overflow-y-auto scroll-smooth rounded-lg border bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800"
+  class="h-[50vh] space-y-1 overflow-y-auto scroll-smooth rounded-lg border bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800 lg:h-full"
 >
   {#if dialogues.length > 0}
+    <!--
+      上下の余白（50% - 1.25rem）は、アクティブな項目が中央に来るように調整するためのものです。
+      1.25rem は、p-3（0.75rem）と rounded-lg の境界付近の余白を考慮したおおよその値です。
+    -->
     <div class="h-[calc(50%-1.25rem)]"></div>
     {#each dialogues as dialogue, index (dialogue.id)}
       <div

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,6 @@
   let { children } = $props();
 </script>
 
-<div class="container mx-auto px-4">
+<div class="h-screen w-full">
   {@render children()}
 </div>

--- a/src/routes/episode/[id]/+page.svelte
+++ b/src/routes/episode/[id]/+page.svelte
@@ -83,11 +83,13 @@
   }
 </script>
 
-<div class="p-4 md:p-6">
-  <Button color="light" class="mb-4" onclick={goBack}>
-    <ArrowLeftOutline class="me-2 h-5 w-5" />
-    {t('episodeDetailPage.backButton')}
-  </Button>
+<div class="p-4 md:p-6 lg:flex lg:h-full lg:flex-col">
+  <div>
+    <Button color="light" class="mb-4" onclick={goBack}>
+      <ArrowLeftOutline class="me-2 h-5 w-5" />
+      {t('episodeDetailPage.backButton')}
+    </Button>
+  </div>
 
   {#if errorMessage}
     <Alert color="red">
@@ -96,19 +98,20 @@
       {errorMessage}
     </Alert>
   {:else if data.episode}
-    <div class="grid grid-cols-1 gap-8 lg:grid-cols-3">
-      <div class="lg:col-span-2">
-        <Heading tag="h1" class="mb-2 text-3xl font-bold">{data.episode.title}</Heading>
-        <p class="mb-6 text-gray-500">
-          {t('episodeDetailPage.playbackTime', {
-            minutes: Math.floor((data.episode.durationSeconds ?? 0) / 60),
-            seconds: Math.floor((data.episode.durationSeconds ?? 0) % 60),
-          })}
-        </p>
+    <div class="grid grid-cols-1 gap-8 lg:grid-cols-3 lg:flex-1 lg:min-h-0">
+      <div class="flex flex-col lg:col-span-2 lg:min-h-0">
+        <div>
+          <Heading tag="h1" class="mb-2 text-3xl font-bold">{data.episode.title}</Heading>
+          <p class="mb-6 text-gray-500">
+            {t('episodeDetailPage.playbackTime', {
+              minutes: Math.floor((data.episode.durationSeconds ?? 0) / 60),
+              seconds: Math.floor((data.episode.durationSeconds ?? 0) % 60),
+            })}
+          </p>
+          <AudioPlayer src={data.audioBlobUrl} bind:currentTime />
+        </div>
 
-        <AudioPlayer src={data.audioBlobUrl} bind:currentTime />
-
-        <div class="mt-6">
+        <div class="mt-6 flex flex-col lg:flex-1 lg:min-h-0">
           <Heading tag="h2" class="mb-3 text-xl font-semibold">
             {t('episodeDetailPage.scriptTitle')}
           </Heading>
@@ -124,7 +127,7 @@
         </div>
       </div>
 
-      <div class="lg:col-span-1">
+      <div class="flex flex-col lg:col-span-1 lg:min-h-0">
         <Heading tag="h2" class="mb-3 text-xl font-semibold">
           {t('episodeDetailPage.sentenceCardsTitle')}
         </Heading>


### PR DESCRIPTION
This pull request introduces layout and style improvements across several components and pages to enhance responsiveness and usability, especially on large screens. The main focus is on making the episode detail page and related components adapt better to different viewport sizes by utilizing flexbox and height constraints.

**Layout and Responsiveness Enhancements:**

* Updated the main application container in `+layout.svelte` to use full viewport height and width, improving overall layout consistency.
* Refactored the episode detail page container and its main sections to use flexbox (`lg:flex`, `lg:flex-col`, `lg:flex-1`, `lg:min-h-0`) for better vertical and horizontal resizing on large screens. ([src/routes/episode/[id]/+page.svelteL86-R92](diffhunk://#diff-2c5925c31b95a7b9fa86a8cc5022ac60ecd0b8e8cb17d4ea92861593c8befc77L86-R92), [src/routes/episode/[id]/+page.svelteL99-R114](diffhunk://#diff-2c5925c31b95a7b9fa86a8cc5022ac60ecd0b8e8cb17d4ea92861593c8befc77L99-R114), [src/routes/episode/[id]/+page.svelteL127-R130](diffhunk://#diff-2c5925c31b95a7b9fa86a8cc5022ac60ecd0b8e8cb17d4ea92861593c8befc77L127-R130))

**Component Scroll and Height Adjustments:**

* Made the `SentenceCardList.svelte` container scrollable and full-height on large screens for improved usability when viewing many cards.
* Adjusted `TranscriptViewer.svelte` to use a responsive height (`h-[50vh]` and `lg:h-full`) and clarified vertical spacing logic for centering active items, enhancing transcript navigation.