### PR TITLE
fix: default group name of GroupNameEditModal component

### DIFF
--- a/src/lib/presentation/components/GroupNameEditModal.svelte
+++ b/src/lib/presentation/components/GroupNameEditModal.svelte
@@ -4,14 +4,14 @@
 
   type Props = {
     show: boolean;
-    isSubmitting?: boolean;
-    initialName?: string;
+    isSubmitting: boolean;
+    initialName: string;
     onClose: () => void;
     onSubmit: (_name: string) => void;
   };
-  let { show, isSubmitting = false, initialName = '', onClose, onSubmit }: Props = $props();
+  let { show, isSubmitting, initialName, onClose, onSubmit }: Props = $props();
 
-  let name = $state(initialName);
+  let name = $derived(initialName);
   let errorMessage = $state('');
 
   function handleSubmit() {


### PR DESCRIPTION
This pull request makes a small update to the `GroupNameEditModal.svelte` component to simplify the handling of props and state.

* Props `isSubmitting` and `initialName` are now required instead of optional, and their default values have been removed. (`[src/lib/presentation/components/GroupNameEditModal.svelteL7-R14](diffhunk://#diff-ef908979e04be5a3f7b73d05dc7e1dc010e14d0172823e56afa99131731cdb2dL7-R14)`)
* The local `name` variable is now derived directly from `initialName` instead of using a state variable. (`[src/lib/presentation/components/GroupNameEditModal.svelteL7-R14](diffhunk://#diff-ef908979e04be5a3f7b73d05dc7e1dc010e14d0172823e56afa99131731cdb2dL7-R14)`)