### PR TITLE
fix: update publish workflow to include additional GStreamer dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# cSpell:ignore libwebkit libappindicator librsvg patchelf dtolnay swatinem
+# cSpell:ignore libwebkit libappindicator librsvg patchelf dtolnay swatinem gstreamer libav
 name: 'publish'
 
 on:
@@ -30,7 +30,18 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils file
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            xdg-utils \
+            file \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-plugins-ugly \
+            gstreamer1.0-libav
 
       - name: setup node
         uses: actions/setup-node@v4


### PR DESCRIPTION
This pull request updates the Ubuntu dependencies in the GitHub Actions workflow for publishing. The main change is the addition of several GStreamer-related packages to the list of required dependencies, which will help support media functionality in builds.

Dependency updates:

* Added `gstreamer1.0-plugins-base`, `gstreamer1.0-plugins-good`, `gstreamer1.0-plugins-bad`, `gstreamer1.0-plugins-ugly`, and `gstreamer1.0-libav` to the list of packages installed for the `ubuntu-22.04` platform in the `publish.yml` workflow.
* Updated the cSpell ignore list to include `gstreamer` and `libav` to prevent spelling errors for these new dependencies.