### PR TITLE
fix dialogue analysis caching by retrieving translation and explanation

### DIFF
--- a/src/lib/application/usecases/analyzeDialogueForMining.ts
+++ b/src/lib/application/usecases/analyzeDialogueForMining.ts
@@ -47,23 +47,23 @@ export async function analyzeDialogueForMining(
   context: readonly Dialogue[]
 ): Promise<SentenceAnalysisResult> {
   // 1. キャッシュを確認
-  if (dialogue.translation && dialogue.explanation) {
-    const cachedCards = await sentenceCardRepository.getSentenceCardsByDialogueId(dialogue.id);
-    if (cachedCards.length > 0) {
-      return {
-        translation: dialogue.translation,
-        explanation: dialogue.explanation,
-        items: cachedCards.map((card) => ({
-          id: card.id,
-          expression: card.expression,
-          partOfSpeech: card.partOfSpeech,
-          contextualDefinition: card.contextualDefinition,
-          coreMeaning: card.coreMeaning,
-          exampleSentence: card.sentence,
-          status: card.status,
-        })),
-      };
-    }
+  const cachedCards = await sentenceCardRepository.getSentenceCardsByDialogueId(dialogue.id);
+  if (cachedCards.length > 0) {
+    // ダイアログの翻訳と説明をキャッシュから取得
+    const cachedDialogue = await dialogueRepository.getDialogueById(dialogue.id);
+    return {
+      translation: cachedDialogue?.translation || '',
+      explanation: cachedDialogue?.explanation || '',
+      items: cachedCards.map((card) => ({
+        id: card.id,
+        expression: card.expression,
+        partOfSpeech: card.partOfSpeech,
+        contextualDefinition: card.contextualDefinition,
+        coreMeaning: card.coreMeaning,
+        exampleSentence: card.sentence,
+        status: card.status,
+      })),
+    };
   }
 
   // 2. キャッシュがなければLLMで解析

--- a/src/lib/infrastructure/repositories/dialogueRepository.ts
+++ b/src/lib/infrastructure/repositories/dialogueRepository.ts
@@ -27,6 +27,14 @@ function mapRowToDialogue(row: DialogueRow): Dialogue {
 }
 
 export const dialogueRepository = {
+  async getDialogueById(dialogueId: number): Promise<Dialogue | null> {
+    const db = new Database(getDatabasePath());
+    const rows = await db.select<DialogueRow[]>('SELECT * FROM dialogues WHERE id = ?', [
+      dialogueId,
+    ]);
+    return rows.length > 0 ? mapRowToDialogue(rows[0]) : null;
+  },
+
   async getDialoguesByEpisodeId(episodeId: number): Promise<readonly Dialogue[]> {
     const db = new Database(getDatabasePath());
     const rows = await db.select<DialogueRow[]>(


### PR DESCRIPTION
This pull request improves how cached dialogue data is retrieved and used during sentence analysis. The main change is that, instead of relying on potentially stale in-memory properties, the code now fetches the latest translation and explanation directly from the database when cached sentence cards are present. Additionally, a new method is introduced to the dialogue repository for fetching a dialogue by its ID.

**Caching and data retrieval improvements:**

* In `analyzeDialogueForMining`, when cached sentence cards are found, the code now fetches the dialogue's translation and explanation from the database using `getDialogueById`, ensuring the most up-to-date information is returned.

**Repository enhancements:**

* Added a new `getDialogueById` method to `dialogueRepository` in `dialogueRepository.ts` to support fetching a single dialogue by its ID from the database.

**Logic simplification:**

* Removed unnecessary conditional nesting in `analyzeDialogueForMining` after the cache check, simplifying the control flow.