### PR TITLE
Refactoring

### DIFF
--- a/doc/technical_specifications.md
+++ b/doc/technical_specifications.md
@@ -314,7 +314,32 @@ Sentence Miningによって作成されたカードを管理する。
 Rustで実装し、フロントエンドの`Infrastructure`レイヤーから呼び出される関数群。
 Tauriのプラグインを利用するなどしてフロントエンド側で実装可能と判断したものは、必ずしも Rust 側で実装しなくても良い。
 
-- `analyze_sentence_with_llm(learning_language: String, explanation_language: String, part_of_speech_options: Vec<String>, context: String, target_sentence: String) -> Result<SentenceMiningResult, String>`
+#### LLM
+
+- `analyze_sentence_with_llm(api_key: String, learning_language: String, explanation_language: String, part_of_speech_options: Vec<String>, context: String, target_sentence: String) -> Result<SentenceMiningResult, String>`
+  - センテンスを解析し、単語や表現の情報をLLMから取得する。
+  - `SentenceMiningResult` は `translation`, `explanation`, `items` を含む。
+
+#### Stronghold (Secure Storage)
+
+- `get_stronghold_password() -> Result<String, String>`
+  - OSのキーチェーンからStrongholdのパスワードを取得または生成して返す。
+
+#### Audio Playback
+
+- `open_audio(path: String, max_peaks: usize) -> Result<AudioInfo, String>`
+  - 音声ファイルを指定されたパスから開き、解析して波形データと再生時間を返す。
+  - `AudioInfo` は `duration`, `peaks` を含む。
+- `play_audio() -> Result<(), String>`
+  - `open_audio` で開かれた音声の再生を開始する。
+- `pause_audio() -> Result<(), String>`
+  - 音声の再生を一時停止する。
+- `resume_audio() -> Result<(), String>`
+  - 一時停止した音声の再生を再開する。
+- `stop_audio() -> Result<(), String>`
+  - 音声の再生を停止する。
+- `seek_audio(position_ms: u32) -> Result<(), String>`
+  - 音声の再生位置を指定された時間（ミリ秒）に移動する。
 
 ### 4.3. データフェッチ・状態管理戦略
 

--- a/doc/technical_specifications.md
+++ b/doc/technical_specifications.md
@@ -209,13 +209,13 @@ erDiagram
 ### 2.1. `episode_groups` テーブル
 エピソードを任意のグループ（入れ子構造可）に分類する。
 
-| カラム名         | 型      | 説明                         |
-|------------------|---------|------------------------------|
-| `id`             | INTEGER | PRIMARY KEY, AUTOINCREMENT   |
-| `name`           | TEXT    | グループ名                   |
-| `display_order`  | INTEGER | グループの表示順序           |
-| `parent_group_id`| INTEGER | 親グループID（NULLでルート） |
-| `group_type`     | TEXT    | グループ種別: "album"（エピソード格納可）または "folder"（サブグループのみ格納可） |
+| カラム名         | 型      | NULL許容 | 説明                         |
+|------------------|---------|----------|------------------------------|
+| `id`             | INTEGER |          | PRIMARY KEY, AUTOINCREMENT   |
+| `name`           | TEXT    |          | グループ名                   |
+| `display_order`  | INTEGER |          | グループの表示順序           |
+| `parent_group_id`| INTEGER | ●        | 親グループID（NULLでルート） |
+| `group_type`     | TEXT    |          | グループ種別: "album"（エピソード格納可）または "folder"（サブグループのみ格納可） |
 
 - `parent_group_id`は自己参照外部キー。NULLの場合はルートグループ。
 - `group_type` でグループの種別を区別する。`album` はエピソードを格納でき、`folder` はサブグループのみ格納できる。
@@ -224,34 +224,34 @@ erDiagram
 ### 2.2. `episodes` テーブル
 エピソード（音声コンテンツとスクリプトのセット）を管理する。
 
-| カラム名        | 型          | 説明                               |
-|-----------------|-------------|------------------------------------|
-| `id`            | INTEGER     | PRIMARY KEY, AUTOINCREMENT         |
-| `episode_group_id` | INTEGER  | `episode_groups.id`への外部キー    |
-| `display_order` | INTEGER     | グループ内でのエピソードの表示順序 |
-| `title`         | TEXT        | エピソードのタイトル               |
-| `audio_path`    | TEXT        | 音声ファイルのパス             |
-| `script_path`   | TEXT        | スクリプトファイルのパス       |
-| `duration_seconds` | INTEGER  | 音声の再生時間（秒）               |
-| `learning_language` | TEXT    | 学習ターゲット言語 (例: 'English') |
-| `explanation_language` | TEXT  | 説明言語 (例: 'Japanese')        |
-| `created_at`    | TEXT        | 作成日時 (ISO 8601)                |
-| `updated_at`    | TEXT        | 更新日時 (ISO 8601)                |
+| カラム名        | 型          | NULL許容 | 説明                               |
+|-----------------|-------------|----------|------------------------------------|
+| `id`            | INTEGER     |          | PRIMARY KEY, AUTOINCREMENT         |
+| `episode_group_id` | INTEGER  |          | `episode_groups.id`への外部キー    |
+| `display_order` | INTEGER     |          | グループ内でのエピソードの表示順序 |
+| `title`         | TEXT        |          | エピソードのタイトル               |
+| `audio_path`    | TEXT        |          | 音声ファイルのパス             |
+| `script_path`   | TEXT        |          | スクリプトファイルのパス       |
+| `duration_seconds` | INTEGER  | ●        | 音声の再生時間（秒）               |
+| `learning_language` | TEXT    |          | 学習ターゲット言語 (例: 'English') |
+| `explanation_language` | TEXT  |          | 説明言語 (例: 'Japanese')        |
+| `created_at`    | TEXT        |          | 作成日時 (ISO 8601)                |
+| `updated_at`    | TEXT        |          | 更新日時 (ISO 8601)                |
 
 ### 2.3. `dialogues` テーブル
 スクリプト内の各セリフを管理する。
 
-| カラム名          | 型          | 説明                               |
-|-------------------|-------------|------------------------------------|
-| `id`              | INTEGER     | PRIMARY KEY, AUTOINCREMENT         |
-| `episode_id`      | INTEGER     | `episodes.id`への外部キー          |
-| `start_time_ms`   | INTEGER     | セリフの開始時間（ミリ秒）         |
-| `end_time_ms`     | INTEGER     | セリフの終了時間（ミリ秒）         |
-| `original_text`   | TEXT        | スクリプトから取り込んだ元のテキスト |
-| `corrected_text`  | TEXT        | ユーザーが修正した後のテキスト     |
-| `translation`     | TEXT        | LLMが生成した翻訳                  |
-| `explanation`     | TEXT        | LLMが生成した翻訳の解説            |
-| `deleted_at`      | TEXT        | 削除日時 (ISO 8601), NULLの場合は未削除 |
+| カラム名          | 型          | NULL許容 | 説明                               |
+|-------------------|-------------|----------|------------------------------------|
+| `id`              | INTEGER     |          | PRIMARY KEY, AUTOINCREMENT         |
+| `episode_id`      | INTEGER     |          | `episodes.id`への外部キー          |
+| `start_time_ms`   | INTEGER     |          | セリフの開始時間（ミリ秒）         |
+| `end_time_ms`     | INTEGER     |          | セリフの終了時間（ミリ秒）         |
+| `original_text`   | TEXT        |          | スクリプトから取り込んだ元のテキスト |
+| `corrected_text`  | TEXT        | ●        | ユーザーが修正した後のテキスト     |
+| `translation`     | TEXT        | ●        | LLMが生成した翻訳                  |
+| `explanation`     | TEXT        | ●        | LLMが生成した翻訳の解説            |
+| `deleted_at`      | TEXT        | ●        | 削除日時 (ISO 8601), NULLの場合は未削除 |
 
 ### 2.4. `sentence_cards` テーブル
 Sentence Miningによって作成されたカードを管理する。
@@ -262,17 +262,17 @@ Sentence Miningによって作成されたカードを管理する。
     - 例: `CREATE VIRTUAL TABLE sentence_cards USING fts5(expression);`
 - 単語の順序や部分列一致など、より高度な検索条件（例: "pick up [-]" のようなパターン）は、アプリケーション側でトークン化・フィルタリング処理を行う。
 
-| カラム名        | 型          | 説明                               |
-|-----------------|-------------|------------------------------------|
-| `id`            | INTEGER     | PRIMARY KEY, AUTOINCREMENT         |
-| `dialogue_id`   | INTEGER     | `dialogues.id`への外部キー         |
-| `part_of_speech`| TEXT        | 品詞                         |
-| `expression`    | TEXT        | 抽出対象の単語/イディオム          |
-| `sentence`      | TEXT        | 抽出対象を含むセンテンス全体（該当箇所を強調）       |
-| `contextual_definition`    | TEXT        | LLMによって生成された文脈上の意味    |
-| `core_meaning`    | TEXT        | LLMによって生成された核となる意味    |
-| `status`        | TEXT        | `active` (学習中), `suspended` (保留), `cache` (LLM解析結果のキャッシュ) などの状態 |
-| `created_at`    | TEXT        | 作成日時 (ISO 8601)                |
+| カラム名        | 型          | NULL許容 | 説明                               |
+|-----------------|-------------|----------|------------------------------------|
+| `id`            | INTEGER     |          | PRIMARY KEY, AUTOINCREMENT         |
+| `dialogue_id`   | INTEGER     |          | `dialogues.id`への外部キー         |
+| `part_of_speech`| TEXT        |          | 品詞                         |
+| `expression`    | TEXT        |          | 抽出対象の単語/イディオム          |
+| `sentence`      | TEXT        |          | 抽出対象を含むセンテンス全体（該当箇所を強調）       |
+| `contextual_definition`    | TEXT        |          | LLMによって生成された文脈上の意味    |
+| `core_meaning`    | TEXT        |          | LLMによって生成された核となる意味    |
+| `status`        | TEXT        |          | `active` (学習中), `suspended` (保留), `cache` (LLM解析結果のキャッシュ) などの状態 |
+| `created_at`    | TEXT        |          | 作成日時 (ISO 8601)                |
 
 ---
 

--- a/src/lib/domain/entities/dialogue.ts
+++ b/src/lib/domain/entities/dialogue.ts
@@ -1,14 +1,20 @@
 /**
- * スクリプト内の個々のセリフを表すエンティティ。
+ * 新規作成時に必要なプロパティをまとめた型。
  */
-export type Dialogue = {
-  readonly id: number;
+export type NewDialogue = {
   readonly episodeId: number;
   readonly startTimeMs: number;
   readonly endTimeMs: number;
   readonly originalText: string;
+};
+
+/**
+ * スクリプト内の個々のセリフを表すエンティティ。
+ */
+export type Dialogue = NewDialogue & {
+  readonly id: number;
   readonly correctedText: string | null;
   readonly translation: string | null;
   readonly explanation: string | null;
-  readonly deleted_at: string | null;
+  readonly deletedAt: string | null;
 };

--- a/src/lib/domain/services/parseSrtToDialogues.test.ts
+++ b/src/lib/domain/services/parseSrtToDialogues.test.ts
@@ -14,26 +14,16 @@ This is a test.
     const { dialogues, warnings } = parseSrtToDialogues(srtContent, episodeId);
     expect(dialogues.length).toBe(2);
     expect(dialogues[0]).toEqual({
-      id: 0,
       episodeId: 1,
       startTimeMs: 1000,
       endTimeMs: 3000,
       originalText: 'Hello, world.',
-      correctedText: null,
-      explanation: null,
-      translation: null,
-      deleted_at: null,
     });
     expect(dialogues[1]).toEqual({
-      id: 0,
       episodeId: 1,
       startTimeMs: 4000,
       endTimeMs: 6000,
       originalText: 'This is a test.',
-      correctedText: null,
-      explanation: null,
-      translation: null,
-      deleted_at: null,
     });
     expect(warnings.length).toBe(0);
   });

--- a/src/lib/domain/services/parseSrtToDialogues.ts
+++ b/src/lib/domain/services/parseSrtToDialogues.ts
@@ -1,4 +1,4 @@
-import type { Dialogue } from '$lib/domain/entities/dialogue';
+import type { NewDialogue } from '$lib/domain/entities/dialogue';
 
 /**
  * Parses SRT content and converts it into an array of Dialogue objects.
@@ -10,8 +10,8 @@ import type { Dialogue } from '$lib/domain/entities/dialogue';
 export function parseSrtToDialogues(
   srtContent: string,
   episodeId: number
-): { dialogues: readonly Dialogue[]; warnings: readonly string[] } {
-  const dialogues: Dialogue[] = [];
+): { dialogues: readonly NewDialogue[]; warnings: readonly string[] } {
+  const dialogues: NewDialogue[] = [];
   const warnings: string[] = [];
   const normalizedContent = srtContent.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
   const blocks = normalizedContent
@@ -57,15 +57,10 @@ export function parseSrtToDialogues(
     const originalText = textLines.join('\n');
 
     dialogues.push({
-      id: 0, // Placeholder, will be assigned by DB
       episodeId: episodeId,
       startTimeMs: startTimeMs,
       endTimeMs: endTimeMs,
       originalText: originalText,
-      correctedText: null,
-      translation: null,
-      explanation: null,
-      deleted_at: null,
     });
   }
 

--- a/src/lib/domain/services/parseSswtToDialogues.test.ts
+++ b/src/lib/domain/services/parseSswtToDialogues.test.ts
@@ -7,15 +7,10 @@ describe('parseSswtToDialogues', () => {
 
     expect(dialogues).toHaveLength(1);
     expect(dialogues[0]).toEqual({
-      id: 0,
       episodeId: 1,
       startTimeMs: 1000,
       endTimeMs: 2500,
       originalText: 'This is a test sentence.',
-      correctedText: null,
-      translation: null,
-      explanation: null,
-      deleted_at: null,
     });
     expect(warnings).toHaveLength(0);
   });

--- a/src/lib/domain/services/parseSswtToDialogues.ts
+++ b/src/lib/domain/services/parseSswtToDialogues.ts
@@ -1,4 +1,4 @@
-import type { Dialogue } from '$lib/domain/entities/dialogue';
+import type { NewDialogue } from '$lib/domain/entities/dialogue';
 
 const sswtLineRegex = /^\[(\d{2}:\d{2}:\d{2}\.\d{3}) -> (\d{2}:\d{2}:\d{2}\.\d{3})\]\s*(.*)$/;
 
@@ -36,8 +36,8 @@ function parseTimeToMs(timeString: string): number | null {
 export function parseSswtToDialogues(
   sswtContent: string,
   episodeId: number
-): { dialogues: readonly Dialogue[]; warnings: readonly string[] } {
-  const dialogues: Dialogue[] = [];
+): { dialogues: readonly NewDialogue[]; warnings: readonly string[] } {
+  const dialogues: NewDialogue[] = [];
   const warnings: string[] = [];
   const lines = sswtContent.split('\n');
 
@@ -63,15 +63,10 @@ export function parseSswtToDialogues(
     }
 
     dialogues.push({
-      id: 0, // Placeholder, will be assigned by DB
       episodeId,
       startTimeMs,
       endTimeMs,
       originalText,
-      correctedText: null,
-      translation: null,
-      explanation: null,
-      deleted_at: null,
     });
   }
 

--- a/src/lib/infrastructure/repositories/dialogueRepository.ts
+++ b/src/lib/infrastructure/repositories/dialogueRepository.ts
@@ -1,4 +1,4 @@
-import type { Dialogue } from '$lib/domain/entities/dialogue';
+import type { Dialogue, NewDialogue } from '$lib/domain/entities/dialogue';
 import Database from '@tauri-apps/plugin-sql';
 import { getDatabasePath } from '../config';
 
@@ -24,16 +24,9 @@ function mapRowToDialogue(row: DialogueRow): Dialogue {
     correctedText: row.corrected_text,
     translation: row.translation,
     explanation: row.explanation,
-    deleted_at: row.deleted_at,
+    deletedAt: row.deleted_at,
   };
 }
-
-type NewDialogue = {
-  episodeId: number;
-  startTimeMs: number;
-  endTimeMs: number;
-  originalText: string;
-};
 
 export const dialogueRepository = {
   async getDialogueById(dialogueId: number): Promise<Dialogue | null> {

--- a/src/lib/presentation/components/TranscriptViewer.svelte
+++ b/src/lib/presentation/components/TranscriptViewer.svelte
@@ -55,7 +55,7 @@
   let itemEls: (HTMLElement | null)[] = [];
 
   const displayedDialogues = $derived(
-    showDeleted ? dialogues : dialogues.filter((d) => d.deleted_at === null)
+    showDeleted ? dialogues : dialogues.filter((d) => d.deletedAt === null)
   );
 
   // currentTimeが変更されたら、activeIndexとpreviousActiveIndexを更新し、該当要素までスクロールする$effect
@@ -102,7 +102,7 @@
   }
 
   function handleDblClick(dialogue: Dialogue) {
-    if (dialogue.deleted_at) return;
+    if (dialogue.deletedAt) return;
     editingDialogueId = dialogue.id;
     editText = dialogue.correctedText || dialogue.originalText;
     editingOriginalText = dialogue.originalText;
@@ -157,23 +157,23 @@
         class="flex items-center justify-between rounded-lg p-3 transition-all"
         class:bg-primary-100={index === activeIndex &&
           editingDialogueId === null &&
-          !dialogue.deleted_at}
+          !dialogue.deletedAt}
         class:dark:bg-primary-900={index === activeIndex &&
           editingDialogueId === null &&
-          !dialogue.deleted_at}
+          !dialogue.deletedAt}
         class:bg-gray-200={index === previousActiveIndex &&
           index !== activeIndex &&
           editingDialogueId === null &&
-          !dialogue.deleted_at}
+          !dialogue.deletedAt}
         class:dark:bg-gray-700={index === previousActiveIndex &&
           index !== activeIndex &&
           editingDialogueId === null &&
-          !dialogue.deleted_at}
+          !dialogue.deletedAt}
         class:ring-2={editingDialogueId === dialogue.id}
         class:ring-primary-500={editingDialogueId === dialogue.id}
-        class:bg-red-100={!!dialogue.deleted_at}
-        class:dark:bg-red-900={!!dialogue.deleted_at}
-        class:dark:bg-opacity-50={!!dialogue.deleted_at}
+        class:bg-red-100={!!dialogue.deletedAt}
+        class:dark:bg-red-900={!!dialogue.deletedAt}
+        class:dark:bg-opacity-50={!!dialogue.deletedAt}
       >
         {#if editingDialogueId === dialogue.id}
           <div class="flex w-full flex-col space-y-2">
@@ -210,21 +210,21 @@
             role="button"
             tabindex="0"
             class="flex-1"
-            class:cursor-pointer={!dialogue.deleted_at}
-            class:text-primary-800={index === activeIndex && !dialogue.deleted_at}
-            class:dark:text-primary-200={index === activeIndex && !dialogue.deleted_at}
-            class:line-through={!!dialogue.deleted_at}
-            class:text-gray-500={!!dialogue.deleted_at}
-            onclick={() => !dialogue.deleted_at && onSeek(dialogue.startTimeMs)}
+            class:cursor-pointer={!dialogue.deletedAt}
+            class:text-primary-800={index === activeIndex && !dialogue.deletedAt}
+            class:dark:text-primary-200={index === activeIndex && !dialogue.deletedAt}
+            class:line-through={!!dialogue.deletedAt}
+            class:text-gray-500={!!dialogue.deletedAt}
+            onclick={() => !dialogue.deletedAt && onSeek(dialogue.startTimeMs)}
             ondblclick={() => handleDblClick(dialogue)}
             onkeydown={(e) =>
-              e.key === 'Enter' && !dialogue.deleted_at && onSeek(dialogue.startTimeMs)}
+              e.key === 'Enter' && !dialogue.deletedAt && onSeek(dialogue.startTimeMs)}
           >
             {dialogue.correctedText || dialogue.originalText}
           </div>
 
           <div class="w-24 text-right">
-            {#if dialogue.deleted_at}
+            {#if dialogue.deletedAt}
               <Button size="xs" color="alternative" onclick={() => onUndoDelete(dialogue.id)}>
                 <RedoOutline class="me-1 h-4 w-4" />
                 {t('common.undo')}

--- a/src/routes/episode/[id]/+page.svelte
+++ b/src/routes/episode/[id]/+page.svelte
@@ -51,7 +51,7 @@
   let isConfirmModalOpen = $state(false);
   let dialogueToDeleteId: number | null = $state(null);
 
-  const hasDeletedDialogues = $derived(data.dialogues?.some((d) => d.deleted_at !== null) ?? false);
+  const hasDeletedDialogues = $derived(data.dialogues?.some((d) => d.deletedAt !== null) ?? false);
 
   let unlisten: (() => void) | undefined;
 


### PR DESCRIPTION
This pull request refactors the handling of the `Dialogue` entity and related code, focusing on clarifying the distinction between new and existing dialogues, improving type safety, and ensuring consistent naming conventions across the codebase and documentation. The changes also update the technical specification to make the database schema's nullability explicit.

**Domain Model and Type Improvements:**

- Introduced a new `NewDialogue` type in `dialogue.ts` to represent the properties required when creating a new dialogue, and redefined `Dialogue` to extend `NewDialogue` with additional fields for persisted entities.
- Updated all usages of dialogue creation and parsing (in `parseSrtToDialogues.ts` and `parseSswtToDialogues.ts`) to use the new `NewDialogue` type instead of the full `Dialogue` type, removing placeholder fields that are only present after persistence. [[1]](diffhunk://#diff-7ea54deed0fa941a428817a5a1897dcda2c8b50fa409340fb581c45bd9d66fd5L1-R1) [[2]](diffhunk://#diff-7ea54deed0fa941a428817a5a1897dcda2c8b50fa409340fb581c45bd9d66fd5L13-R14) [[3]](diffhunk://#diff-7ea54deed0fa941a428817a5a1897dcda2c8b50fa409340fb581c45bd9d66fd5L60-L68) [[4]](diffhunk://#diff-ae6bff6ad55dc8697c85504ff1f2813cfb2899ce54cbb51b142cb4c432239ee0L1-R1) [[5]](diffhunk://#diff-ae6bff6ad55dc8697c85504ff1f2813cfb2899ce54cbb51b142cb4c432239ee0L39-R40) [[6]](diffhunk://#diff-ae6bff6ad55dc8697c85504ff1f2813cfb2899ce54cbb51b142cb4c432239ee0L66-L74)

**Naming Consistency and Code Cleanup:**

- Standardized the property name for the deletion timestamp from `deleted_at` to `deletedAt` throughout the domain entities, repository mapping, and all usages in the Svelte components and route files. [[1]](diffhunk://#diff-d2b89650f379be82fdf5dcbc5315730b6d8f80152802bdb53ad8fb697d2abaf0L2-R19) [[2]](diffhunk://#diff-2b88102b10c24d510af32865d380a876bec5c924eb432f3c22f16ccbb0259e67L27-L37) [[3]](diffhunk://#diff-c0c22fbea9e41cb3f10cb9a3f91c2b7a445cd78cdfbb3d7513a968743a00308dL58-R58) [[4]](diffhunk://#diff-c0c22fbea9e41cb3f10cb9a3f91c2b7a445cd78cdfbb3d7513a968743a00308dL105-R105) [[5]](diffhunk://#diff-c0c22fbea9e41cb3f10cb9a3f91c2b7a445cd78cdfbb3d7513a968743a00308dL160-R176) [[6]](diffhunk://#diff-c0c22fbea9e41cb3f10cb9a3f91c2b7a445cd78cdfbb3d7513a968743a00308dL213-R227) [src/routes/episode/[id]/+page.svelteL54-R54](diffhunk://#diff-2c5925c31b95a7b9fa86a8cc5022ac60ecd0b8e8cb17d4ea92861593c8befc77L54-R54))
- Removed redundant or now-unnecessary type definitions and placeholder fields in test files and parsing logic, aligning tests with the updated entity structure. [[1]](diffhunk://#diff-15ba80bc089edfd13e5766a875115ec669866aa33a8c54edad433bcba826a7c7L17-L36) [[2]](diffhunk://#diff-9f3d837df1793f55a8bf44e398fc2df8f7e5a58f08f67174992f0fe5a3300d40L10-L18)

**Documentation and Schema Updates:**

- Updated the technical specification (`technical_specifications.md`) to explicitly add a "NULL許容" (nullable) column to all relevant database table definitions, making nullability clear for each field. [[1]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L212-R218) [[2]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L227-R254) [[3]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L265-R275)
- Expanded the API documentation to clarify input parameters and return values for Rust-side functions, especially for LLM analysis, secure storage, and audio playback.

These changes improve maintainability, reduce ambiguity in entity construction, and provide clearer documentation for both developers and database designers.