### PR TITLE
refactor: remove duration_seconds field from episode

### DIFF
--- a/doc/technical_specifications.md
+++ b/doc/technical_specifications.md
@@ -172,7 +172,6 @@ erDiagram
         TEXT title
         TEXT audio_path
         TEXT script_path
-        INTEGER duration_seconds
         TEXT learning_language
         TEXT explanation_language
         TEXT created_at
@@ -232,7 +231,6 @@ erDiagram
 | `title`         | TEXT        |          | エピソードのタイトル               |
 | `audio_path`    | TEXT        |          | 音声ファイルのパス             |
 | `script_path`   | TEXT        |          | スクリプトファイルのパス       |
-| `duration_seconds` | INTEGER  | ●        | 音声の再生時間（秒）               |
 | `learning_language` | TEXT    |          | 学習ターゲット言語 (例: 'English') |
 | `explanation_language` | TEXT  |          | 説明言語 (例: 'Japanese')        |
 | `created_at`    | TEXT        |          | 作成日時 (ISO 8601)                |

--- a/src-tauri/migrations/0001-initial-tables.sql
+++ b/src-tauri/migrations/0001-initial-tables.sql
@@ -13,7 +13,6 @@ CREATE TABLE episodes (
     title TEXT NOT NULL,
     audio_path TEXT NOT NULL,
     script_path TEXT NOT NULL,
-    duration_seconds INTEGER,
     learning_language TEXT NOT NULL DEFAULT 'English',
     explanation_language TEXT NOT NULL DEFAULT 'Japanese',
     created_at TEXT NOT NULL,

--- a/src/lib/domain/entities/episode.ts
+++ b/src/lib/domain/entities/episode.ts
@@ -7,10 +7,7 @@ export type Episode = {
   readonly displayOrder: number;
   readonly title: string;
   readonly audioPath: string;
-  /**
-   * durationSeconds は常に 0 です。将来的に削除予定。
-   */
-  readonly durationSeconds: number;
+
   readonly learningLanguage: string;
   readonly explanationLanguage: string;
   readonly createdAt: Date;

--- a/src/lib/infrastructure/repositories/episodeRepository.ts
+++ b/src/lib/infrastructure/repositories/episodeRepository.ts
@@ -8,7 +8,6 @@ type EpisodeRow = {
   display_order: number;
   title: string;
   audio_path: string;
-  duration_seconds: number;
   learning_language: string;
   explanation_language: string;
   created_at: string;
@@ -23,7 +22,6 @@ function mapRowToEpisode(row: EpisodeRow): Episode {
     displayOrder: row.display_order,
     title: row.title,
     audioPath: row.audio_path,
-    durationSeconds: row.duration_seconds,
     learningLanguage: row.learning_language,
     explanationLanguage: row.explanation_language,
     createdAt: new Date(row.created_at),
@@ -95,15 +93,14 @@ export const episodeRepository = {
     const db = new Database(getDatabasePath());
     const now = new Date().toISOString();
     await db.execute(
-      `INSERT INTO episodes (episode_group_id, display_order, title, audio_path, script_path, duration_seconds, learning_language, explanation_language, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO episodes (episode_group_id, display_order, title, audio_path, script_path, learning_language, explanation_language, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         params.episodeGroupId,
         params.displayOrder,
         params.title,
         params.audioPath,
         params.scriptPath,
-        0, // duration_seconds is always 0
         params.learningLanguage,
         params.explanationLanguage,
         now,


### PR DESCRIPTION
This pull request removes the unused `duration_seconds` field from the episode-related data structures, database schema, and documentation. This simplifies the codebase and keeps the data model clean.

**Database and Data Model Cleanup:**

* Removed the `duration_seconds` column from the `episodes` table schema in `0001-initial-tables.sql`.
* Updated the episode repository code by removing all references to `duration_seconds` in the TypeScript types, mapping functions, and SQL queries in `episodeRepository.ts`. [[1]](diffhunk://#diff-d647397fb2ce405eee18a01003cce2897a2cd9c000bc08440a2c8f2d7a16722cL11) [[2]](diffhunk://#diff-d647397fb2ce405eee18a01003cce2897a2cd9c000bc08440a2c8f2d7a16722cL26) [[3]](diffhunk://#diff-d647397fb2ce405eee18a01003cce2897a2cd9c000bc08440a2c8f2d7a16722cL98-L106)
* Removed the `durationSeconds` property from the `Episode` domain entity in `episode.ts`.

**Documentation Update:**

* Removed the `duration_seconds` field from the ER diagram and episode table documentation in `technical_specifications.md`. [[1]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L175) [[2]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L235)