### PR TITLE
Keyboard shortcut

### DIFF
--- a/doc/dependency-graph.md
+++ b/doc/dependency-graph.md
@@ -13,6 +13,7 @@ graph LR
                 subgraph "stores"
                     src_lib_application_stores_apiKeyStore_svelte_ts["apiKeyStore.svelte.ts"]
                     src_lib_application_stores_audioInfoCacheStore_svelte_ts["audioInfoCacheStore.svelte.ts"]
+                    src_lib_application_stores_audioPlayerStore_svelte_ts["audioPlayerStore.svelte.ts"]
                     src_lib_application_stores_groupPathStore_svelte_ts["groupPathStore.svelte.ts"]
                     src_lib_application_stores_i18n_svelte_ts["i18n.svelte.ts"]
                 end
@@ -83,6 +84,9 @@ graph LR
                 end
             end
             subgraph "presentation"
+                subgraph "actions"
+                    src_lib_presentation_actions_keyboardShortcuts_ts["keyboardShortcuts.ts"]
+                end
                 subgraph "components"
                     src_lib_presentation_components_AudioPlayer_svelte["AudioPlayer.svelte"]
                     src_lib_presentation_components_Breadcrumbs_svelte["Breadcrumbs.svelte"]
@@ -133,6 +137,7 @@ graph LR
             end
         end
 src_lib_application_stores_audioInfoCacheStore_svelte_ts --> src_lib_domain_entities_audioInfo_ts
+src_lib_application_stores_audioPlayerStore_svelte_ts --> src_lib_application_usecases_controlAudio_ts
 src_lib_application_stores_groupPathStore_svelte_ts --> src_lib_domain_entities_episodeGroup_ts
 src_lib_application_stores_i18n_svelte_ts --> src_lib_application_locales_en_ts
 src_lib_application_stores_i18n_svelte_ts --> src_lib_application_locales_ja_ts
@@ -235,6 +240,8 @@ src_lib_infrastructure_repositories_sentenceCardRepository_ts --> src_lib_domain
 src_lib_infrastructure_repositories_sentenceCardRepository_ts --> src_lib_domain_entities_sentenceCard_ts
 src_lib_infrastructure_repositories_sentenceCardRepository_ts --> src_lib_infrastructure_config_ts
 src_lib_infrastructure_repositories_settingsRepository_ts --> src_lib_domain_entities_settings_ts
+src_lib_presentation_actions_keyboardShortcuts_ts --> src_lib_application_stores_audioPlayerStore_svelte_ts
+src_lib_presentation_actions_keyboardShortcuts_ts --> src_lib_domain_entities_dialogue_ts
 src_lib_presentation_components_Breadcrumbs_svelte --> src_lib_application_stores_i18n_svelte_ts
 src_lib_presentation_components_Breadcrumbs_svelte --> src_lib_domain_entities_episodeGroup_ts
 src_lib_presentation_components_ConfirmModal_svelte --> src_lib_application_stores_i18n_svelte_ts
@@ -300,16 +307,17 @@ src_routes_episode_list__groupId___page_svelte --> src_lib_presentation_componen
 src_routes_episode_list__groupId___page_svelte --> src_lib_presentation_components_EpisodeNameEditModal_svelte
 src_routes_episode_list__groupId___page_ts --> src_lib_application_usecases_fetchEpisodes_ts
 src_routes_episode_list__groupId___page_ts --> src_lib_domain_entities_episode_ts
+src_routes_episode__id___page_svelte --> src_lib_application_stores_audioPlayerStore_svelte_ts
 src_routes_episode__id___page_svelte --> src_lib_application_stores_i18n_svelte_ts
 src_routes_episode__id___page_svelte --> src_lib_application_usecases_addSentenceCards_ts
 src_routes_episode__id___page_svelte --> src_lib_application_usecases_analyzeDialogueForMining_ts
-src_routes_episode__id___page_svelte --> src_lib_application_usecases_controlAudio_ts
 src_routes_episode__id___page_svelte --> src_lib_application_usecases_softDeleteDialogue_ts
 src_routes_episode__id___page_svelte --> src_lib_application_usecases_undoSoftDeleteDialogue_ts
 src_routes_episode__id___page_svelte --> src_lib_application_usecases_updateDialogue_ts
 src_routes_episode__id___page_svelte --> src_lib_domain_entities_dialogue_ts
 src_routes_episode__id___page_svelte --> src_lib_domain_entities_sentenceAnalysisResult_ts
 src_routes_episode__id___page_svelte --> src_lib_domain_entities_sentenceCard_ts
+src_routes_episode__id___page_svelte --> src_lib_presentation_actions_keyboardShortcuts_ts
 src_routes_episode__id___page_svelte --> src_lib_presentation_components_AudioPlayer_svelte
 src_routes_episode__id___page_svelte --> src_lib_presentation_components_ConfirmModal_svelte
 src_routes_episode__id___page_svelte --> src_lib_presentation_components_SentenceCardList_svelte

--- a/src/lib/application/stores/audioPlayerStore.svelte.ts
+++ b/src/lib/application/stores/audioPlayerStore.svelte.ts
@@ -1,0 +1,79 @@
+import {
+  listenPlaybackPosition,
+  pauseAudio,
+  playAudio,
+  resumeAudio,
+  seekAudio,
+  stopAudio,
+} from '../usecases/controlAudio';
+
+function createAudioPlayerStore() {
+  let unlisten: (() => void) | undefined;
+
+  const store = $state({
+    isPlaying: false,
+    hasStarted: false,
+    currentTime: 0,
+  });
+
+  async function init() {
+    unlisten = await listenPlaybackPosition((positionMs) => {
+      store.currentTime = positionMs;
+    });
+  }
+
+  function destroy() {
+    if (unlisten) {
+      unlisten();
+    }
+    stop();
+  }
+
+  async function play() {
+    await playAudio();
+    store.isPlaying = true;
+    store.hasStarted = true;
+  }
+
+  async function pause() {
+    await pauseAudio();
+    store.isPlaying = false;
+  }
+
+  async function resume() {
+    await resumeAudio();
+    store.isPlaying = true;
+  }
+
+  function stop() {
+    stopAudio();
+    store.currentTime = 0;
+    store.isPlaying = false;
+    store.hasStarted = false;
+  }
+
+  function seek(time: number) {
+    seekAudio(time);
+  }
+
+  return {
+    get isPlaying() {
+      return store.isPlaying;
+    },
+    get hasStarted() {
+      return store.hasStarted;
+    },
+    get currentTime() {
+      return store.currentTime;
+    },
+    init,
+    destroy,
+    play,
+    pause,
+    resume,
+    stop,
+    seek,
+  };
+}
+
+export const audioPlayerStore = createAudioPlayerStore();

--- a/src/lib/presentation/actions/keyboardShortcuts.ts
+++ b/src/lib/presentation/actions/keyboardShortcuts.ts
@@ -1,0 +1,108 @@
+import type { audioPlayerStore } from '$lib/application/stores/audioPlayerStore.svelte';
+import type { Dialogue } from '$lib/domain/entities/dialogue';
+
+interface KeyboardShortcutsParams {
+  store: typeof audioPlayerStore;
+  dialogues: readonly Dialogue[];
+}
+
+function findCurrentDialogueIndex(time: number, dialogues: readonly Dialogue[]): number {
+  if (dialogues.length === 0) {
+    return -1;
+  }
+
+  let dialogueIndex = -1;
+  for (let i = 0; i < dialogues.length; i++) {
+    if (dialogues[i].startTimeMs <= time) {
+      dialogueIndex = i;
+    } else {
+      break;
+    }
+  }
+  return dialogueIndex;
+}
+
+export function keyboardShortcuts(node: HTMLElement, params: KeyboardShortcutsParams) {
+  let { store, dialogues } = params;
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+      return;
+    }
+
+    if (dialogues.length === 0) return;
+
+    const currentDialogueIndex = findCurrentDialogueIndex(store.currentTime, dialogues);
+
+    switch (event.key) {
+      case 'a': {
+        if (currentDialogueIndex > 0) {
+          const prevDialogue = dialogues[currentDialogueIndex - 1];
+          store.seek(prevDialogue.startTimeMs);
+        } else {
+          store.seek(0);
+        }
+        break;
+      }
+      case 's': {
+        if (currentDialogueIndex !== -1) {
+          const currentDialogue = dialogues[currentDialogueIndex];
+          store.seek(currentDialogue.startTimeMs);
+        }
+        break;
+      }
+      case 'd': {
+        if (currentDialogueIndex < dialogues.length - 1) {
+          const nextDialogue = dialogues[currentDialogueIndex + 1];
+          store.seek(nextDialogue.startTimeMs);
+        }
+        break;
+      }
+      case ' ': {
+        event.preventDefault();
+        if (store.isPlaying) {
+          store.pause();
+        } else {
+          if (store.hasStarted) {
+            store.resume();
+          } else {
+            store.play();
+          }
+        }
+        break;
+      }
+      case 'ArrowUp': {
+        event.preventDefault();
+        store.pause();
+        if (currentDialogueIndex > 0) {
+          const prevDialogue = dialogues[currentDialogueIndex - 1];
+          store.seek(prevDialogue.startTimeMs);
+        } else {
+          store.seek(0);
+        }
+        break;
+      }
+      case 'ArrowDown': {
+        event.preventDefault();
+        store.pause();
+        if (currentDialogueIndex < dialogues.length - 1) {
+          const nextDialogue = dialogues[currentDialogueIndex + 1];
+          store.seek(nextDialogue.startTimeMs);
+        }
+        break;
+      }
+    }
+  }
+
+  window.addEventListener('keydown', handleKeydown);
+
+  return {
+    update(newParams: KeyboardShortcutsParams) {
+      store = newParams.store;
+      dialogues = newParams.dialogues;
+    },
+    destroy() {
+      window.removeEventListener('keydown', handleKeydown);
+    },
+  };
+}

--- a/src/lib/presentation/actions/keyboardShortcuts.ts
+++ b/src/lib/presentation/actions/keyboardShortcuts.ts
@@ -26,7 +26,13 @@ export function keyboardShortcuts(node: HTMLElement, params: KeyboardShortcutsPa
   let { store, dialogues } = params;
 
   function handleKeydown(event: KeyboardEvent) {
-    if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+    const target = event.target as HTMLElement;
+    if (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLSelectElement ||
+      target.isContentEditable
+    ) {
       return;
     }
 

--- a/src/lib/presentation/components/AudioPlayer.svelte
+++ b/src/lib/presentation/components/AudioPlayer.svelte
@@ -4,18 +4,27 @@
     peaks: number[]; // 波形データの配列 (0.0 - 1.0)
     currentTime: number;
     duration: number;
+    isPlaying: boolean;
     onPlay: () => void;
     onPause: () => void;
     onSeek: (_time: number) => void;
     onResume: () => void;
     onStop: () => void;
-    initialIsPlaying?: boolean; // 初期再生状態（オプション）
   };
 
-  let { peaks, currentTime, duration, onPlay, onPause, onSeek, onResume, onStop }: Props = $props();
+  let {
+    peaks,
+    currentTime,
+    duration,
+    isPlaying,
+    onPlay,
+    onPause,
+    onSeek,
+    onResume,
+    onStop,
+  }: Props = $props();
 
   // --- Internal State ---
-  let isPlaying = $state(false);
   let canvasWidth = $state(0);
   let canvasHeight = $state(0);
   let containerElement: HTMLDivElement;
@@ -73,20 +82,17 @@
   function handlePlayPause() {
     if (isPlaying) {
       onPause();
-      isPlaying = false;
     } else {
       if (currentTime > 0) {
         onResume();
       } else {
         onPlay();
       }
-      isPlaying = true;
     }
   }
 
   function handleStop() {
     onStop();
-    isPlaying = false;
   }
 
   // --- Seeking Logic ---

--- a/src/lib/presentation/components/TranscriptViewer.svelte
+++ b/src/lib/presentation/components/TranscriptViewer.svelte
@@ -19,7 +19,6 @@
     dialogues: readonly Dialogue[];
     currentTime: number; // ミリ秒単位
     canMine: boolean; // マイニング可能かどうか
-    showDeleted: boolean; // 削除済みを表示するかどうか
     onSeek: (_time: number) => void;
     onMine: (_dialogue: Dialogue, _context: readonly Dialogue[]) => void;
     onSave: (details: { dialogueId: number; correctedText: string }) => void;
@@ -32,7 +31,6 @@
     dialogues,
     currentTime,
     canMine,
-    showDeleted,
     onSeek,
     onMine,
     onSave,
@@ -54,21 +52,17 @@
   let containerEl: HTMLElement | undefined = $state();
   let itemEls: (HTMLElement | null)[] = [];
 
-  const displayedDialogues = $derived(
-    showDeleted ? dialogues : dialogues.filter((d) => d.deletedAt === null)
-  );
-
   // currentTimeが変更されたら、activeIndexとpreviousActiveIndexを更新し、該当要素までスクロールする$effect
   $effect(() => {
     //編集中は自動スクロールを無効
     if (editingDialogueId !== null) return;
 
-    const newActiveIndex = displayedDialogues.findIndex((d, i) => {
+    const newActiveIndex = dialogues.findIndex((d, i) => {
       if (d.endTimeMs !== null) {
         return currentTime >= d.startTimeMs && currentTime < d.endTimeMs;
       }
 
-      const nextDialogue = displayedDialogues[i + 1];
+      const nextDialogue = dialogues[i + 1];
       if (nextDialogue) {
         return currentTime >= d.startTimeMs && currentTime < nextDialogue.startTimeMs;
       } else {
@@ -110,8 +104,8 @@
 
   function getContext(index: number): readonly Dialogue[] {
     const start = Math.max(0, index - contextBefore);
-    const end = Math.min(displayedDialogues.length, index + contextAfter + 1);
-    return displayedDialogues.slice(start, end);
+    const end = Math.min(dialogues.length, index + contextAfter + 1);
+    return dialogues.slice(start, end);
   }
 
   function handleDblClick(dialogue: Dialogue) {
@@ -124,7 +118,7 @@
   function handleSave() {
     if (editingDialogueId === null) return;
 
-    const dialogue = displayedDialogues.find((d) => d.id === editingDialogueId);
+    const dialogue = dialogues.find((d) => d.id === editingDialogueId);
     if (!dialogue) return;
 
     onSave({
@@ -158,13 +152,13 @@
   bind:this={containerEl}
   class="h-[50vh] space-y-1 overflow-y-auto scroll-smooth rounded-lg border bg-gray-50 p-4 lg:h-full dark:border-gray-700 dark:bg-gray-800"
 >
-  {#if displayedDialogues.length > 0}
+  {#if dialogues.length > 0}
     <!--
       上下の余白（50% - 1.25rem）は、アクティブな項目が中央に来るように調整するためのものです。
       1.25rem は、p-3（0.75rem）と rounded-lg の境界付近の余白を考慮したおおよその値です。
     -->
     <div class="h-[calc(50%-1.25rem)]"></div>
-    {#each displayedDialogues as dialogue, index (dialogue.id)}
+    {#each dialogues as dialogue, index (dialogue.id)}
       <div
         bind:this={itemEls[index]}
         class="flex items-center justify-between rounded-lg p-3 transition-all"


### PR DESCRIPTION
This pull request introduces a new `audioPlayerStore` to centralize and simplify audio playback state and control across the application. It also adds a `keyboardShortcuts` action for improved keyboard accessibility, updates the dependency graph documentation, and refactors related components and pages to use the new store and action. The changes remove duplicated audio logic, streamline state management, and enhance maintainability.

**Audio playback state management:**
* Added `audioPlayerStore` (`src/lib/application/stores/audioPlayerStore.svelte.ts`) to encapsulate audio playback state and control logic, replacing direct audio control calls in components and pages. This includes methods for play, pause, resume, stop, seek, and tracking current time and play state.
* Updated `AudioPlayer.svelte` to use the new `isPlaying` prop and delegate playback actions to the store, removing local playback state. [[1]](diffhunk://#diff-fc162f8287a1d04a3704d00c44e87b86dd973494b9e183fb9136e3588e320ebdR7-L18) [[2]](diffhunk://#diff-fc162f8287a1d04a3704d00c44e87b86dd973494b9e183fb9136e3588e320ebdL76-L89)

**Keyboard accessibility:**
* Introduced `keyboardShortcuts` action (`src/lib/presentation/actions/keyboardShortcuts.ts`), enabling keyboard navigation and playback control tied to the audio player and dialogue list.
* Integrated `keyboardShortcuts` into the episode page, passing the audio player store and filtered dialogues. ([src/routes/episode/[id]/+page.svelteL181-R162](diffhunk://#diff-2c5925c31b95a7b9fa86a8cc5022ac60ecd0b8e8cb17d4ea92861593c8befc77L181-R162))

**Refactoring and cleanup:**
* Refactored `+page.svelte` for episodes to use `audioPlayerStore` for all playback interactions, removed duplicated state and direct usecase calls, and filtered dialogues for display. ([src/routes/episode/[id]/+page.svelteR3-L41](diffhunk://#diff-2c5925c31b95a7b9fa86a8cc5022ac60ecd0b8e8cb17d4ea92861593c8befc77R3-L41), [src/routes/episode/[id]/+page.svelteR42-R57](diffhunk://#diff-2c5925c31b95a7b9fa86a8cc5022ac60ecd0b8e8cb17d4ea92861593c8befc77R42-R57), [src/routes/episode/[id]/+page.svelteL79-R71](diffhunk://#diff-2c5925c31b95a7b9fa86a8cc5022ac60ecd0b8e8cb17d4ea92861593c8befc77L79-R71), [src/routes/episode/[id]/+page.svelteL207-R195](diffhunk://#diff-2c5925c31b95a7b9fa86a8cc5022ac60ecd0b8e8cb17d4ea92861593c8befc77L207-R195), [src/routes/episode/[id]/+page.svelteL234-R221](diffhunk://#diff-2c5925c31b95a7b9fa86a8cc5022ac60ecd0b8e8cb17d4ea92861593c8befc77L234-R221))

**Component updates:**
* Updated `TranscriptViewer.svelte` to remove the `showDeleted` prop and use the filtered dialogues list directly, simplifying state and rendering logic. [[1]](diffhunk://#diff-c0c22fbea9e41cb3f10cb9a3f91c2b7a445cd78cdfbb3d7513a968743a00308dL22) [[2]](diffhunk://#diff-c0c22fbea9e41cb3f10cb9a3f91c2b7a445cd78cdfbb3d7513a968743a00308dL35) [[3]](diffhunk://#diff-c0c22fbea9e41cb3f10cb9a3f91c2b7a445cd78cdfbb3d7513a968743a00308dL57-R65) [[4]](diffhunk://#diff-c0c22fbea9e41cb3f10cb9a3f91c2b7a445cd78cdfbb3d7513a968743a00308dL113-R108) [[5]](diffhunk://#diff-c0c22fbea9e41cb3f10cb9a3f91c2b7a445cd78cdfbb3d7513a968743a00308dL127-R121) [[6]](diffhunk://#diff-c0c22fbea9e41cb3f10cb9a3f91c2b7a445cd78cdfbb3d7513a968743a00308dL161-R161)

**Documentation:**
* Updated `doc/dependency-graph.md` to reflect the new store, action, and their dependencies within the application architecture. [[1]](diffhunk://#diff-6082ffd865579cf88317fe082dc59b122442b4658491c3b5527a57251b9423f4R16) [[2]](diffhunk://#diff-6082ffd865579cf88317fe082dc59b122442b4658491c3b5527a57251b9423f4R87-R89) [[3]](diffhunk://#diff-6082ffd865579cf88317fe082dc59b122442b4658491c3b5527a57251b9423f4R140) [[4]](diffhunk://#diff-6082ffd865579cf88317fe082dc59b122442b4658491c3b5527a57251b9423f4R243-R244) [[5]](diffhunk://#diff-6082ffd865579cf88317fe082dc59b122442b4658491c3b5527a57251b9423f4R310-R320)