### PR TITLE
fix: prevent keyboard shortcuts from triggering only in input and textarea elements

### DIFF
--- a/src/lib/presentation/actions/keyboardShortcuts.ts
+++ b/src/lib/presentation/actions/keyboardShortcuts.ts
@@ -26,6 +26,11 @@ export function keyboardShortcuts(node: HTMLElement, params: KeyboardShortcutsPa
   let { store, dialogues } = params;
 
   function handleKeydown(event: KeyboardEvent) {
+    const target = event.target as HTMLElement;
+    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+      return;
+    }
+
     if (dialogues.length === 0) return;
 
     const currentDialogueIndex = findCurrentDialogueIndex(store.currentTime, dialogues);

--- a/src/lib/presentation/actions/keyboardShortcuts.ts
+++ b/src/lib/presentation/actions/keyboardShortcuts.ts
@@ -26,16 +26,6 @@ export function keyboardShortcuts(node: HTMLElement, params: KeyboardShortcutsPa
   let { store, dialogues } = params;
 
   function handleKeydown(event: KeyboardEvent) {
-    const target = event.target as HTMLElement;
-    if (
-      target instanceof HTMLInputElement ||
-      target instanceof HTMLTextAreaElement ||
-      target instanceof HTMLSelectElement ||
-      target.isContentEditable
-    ) {
-      return;
-    }
-
     if (dialogues.length === 0) return;
 
     const currentDialogueIndex = findCurrentDialogueIndex(store.currentTime, dialogues);


### PR DESCRIPTION
This pull request makes a small change to the keyboard shortcut handler logic by narrowing the conditions under which keyboard shortcuts are ignored. Now, shortcuts are only ignored when the event target is an `HTMLInputElement` or `HTMLTextAreaElement`, rather than also ignoring them for `HTMLSelectElement` and content-editable elements.