### PR TITLE
fix: navigation using breadcrunbs on episode-list page

### DIFF
--- a/src/lib/application/stores/groupPathStore.svelte.ts
+++ b/src/lib/application/stores/groupPathStore.svelte.ts
@@ -13,6 +13,11 @@ export const groupPathStore = {
     return path.length > 0 ? path[path.length - 1] : null;
   },
 
+  // 現在のURLパス
+  get url() {
+    return '/' + path.map((g) => g.id).join('/');
+  },
+
   // パスを一括セット
   setPath(newPath: readonly EpisodeGroup[]) {
     path = newPath;

--- a/src/lib/presentation/components/Breadcrumbs.svelte
+++ b/src/lib/presentation/components/Breadcrumbs.svelte
@@ -14,7 +14,7 @@
   debug(`Breadcrumbs: path=${JSON.stringify(path)}`);
 </script>
 
-<Breadcrumb aria-label="File explorer breadcrumb">
+<Breadcrumb aria-label="Breadcrumb">
   <BreadcrumbItem onclick={() => onNavigate(null)}>
     <HomeOutline class="me-2 h-4 w-4" />
     {t('components.breadcrumbs.home')}

--- a/src/routes/[...groupId]/+page.svelte
+++ b/src/routes/[...groupId]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto, invalidateAll } from '$app/navigation';
-  import { t } from '$lib/application/stores/i18n.svelte';
   import { groupPathStore } from '$lib/application/stores/groupPathStore.svelte';
+  import { t } from '$lib/application/stores/i18n.svelte';
   import { addEpisodeGroup } from '$lib/application/usecases/addEpisodeGroup';
   import { deleteGroupRecursive } from '$lib/application/usecases/deleteGroupRecursive';
   import { fetchAvailableParentGroups } from '$lib/application/usecases/fetchAvailableParentGroups';
@@ -38,12 +38,6 @@
   let path = $derived(groupPathStore.path);
   let currentGroupType = $derived(groupPathStore.current?.groupType ?? 'folder');
 
-  // --- Functions ---
-  function transition() {
-    const pathStr = groupPathStore.path.map((g) => g.id).join('/');
-    goto(`/${pathStr}`);
-  }
-
   // --- Event Handlers ---
 
   // === ページ遷移 ===
@@ -53,13 +47,14 @@
     if (selectedGroup.groupType == 'album') {
       goto(`/episode-list/${selectedGroup.id}`);
     } else {
-      transition();
+      goto(groupPathStore.url);
     }
   }
 
   function handleBreadcrumbClick(targetIndex: number | null) {
-    groupPathStore.popTo(targetIndex);
-    transition();
+    if (groupPathStore.popTo(targetIndex)) {
+      goto(groupPathStore.url);
+    }
   }
 
   async function handleGroupOrderChange(items: readonly EpisodeGroup[]) {

--- a/src/routes/episode-list/[groupId]/+page.svelte
+++ b/src/routes/episode-list/[groupId]/+page.svelte
@@ -41,7 +41,7 @@
   function handleBreadcrumbClick(targetIndex: number | null) {
     debug(`Breadcrumb clicked: targetIndex=${targetIndex}`);
     if (groupPathStore.popTo(targetIndex)) {
-      goto('/');
+      goto(groupPathStore.url);
     }
   }
 


### PR DESCRIPTION
This pull request improves navigation consistency and code maintainability for group path handling across the application. The main change is the introduction of a new `url` getter in the `groupPathStore`, which centralizes the logic for generating the current group path URL. This getter is then used throughout the codebase to simplify navigation and reduce duplication. Additionally, there are minor improvements to accessibility and code organization.

Key changes:

**Navigation and URL Handling Improvements:**

* Added a `url` getter to `groupPathStore` that generates the current group path as a URL, centralizing this logic for reuse.
* Updated navigation logic in `[...groupId]/+page.svelte` and `episode-list/[groupId]/+page.svelte` to use the new `groupPathStore.url` getter instead of manually constructing URLs, improving consistency and reducing code duplication. ([src/routes/[...groupId]/+page.svelteL56-R57](diffhunk://#diff-10381975c71e8c60b852bb79a4187e88ecc6ab59a504b4aefaf5e623b176405dL56-R57), [src/routes/episode-list/[groupId]/+page.svelteL44-R44](diffhunk://#diff-b580de1281047717dbfe76ba19cfc09bc605f0a6c0a7c949862e35a40514b0b1L44-R44))
* Removed the redundant `transition` function from `[...groupId]/+page.svelte` since URL generation is now handled by the store. ([src/routes/[...groupId]/+page.svelteL41-L46](diffhunk://#diff-10381975c71e8c60b852bb79a4187e88ecc6ab59a504b4aefaf5e623b176405dL41-L46))

**Accessibility and UI:**

* Updated the `aria-label` of the `Breadcrumb` component to "Breadcrumb" for clarity and accessibility.

**Code Organization:**

* Minor reordering of imports in `[...groupId]/+page.svelte` for better readability. ([src/routes/[...groupId]/+page.svelteL3-R4](diffhunk://#diff-10381975c71e8c60b852bb79a4187e88ecc6ab59a504b4aefaf5e623b176405dL3-R4))