### PR TITLE
refactor: Change name audio_path to media_path and remove script_path

### DIFF
--- a/doc/technical_specifications.md
+++ b/doc/technical_specifications.md
@@ -171,7 +171,6 @@ erDiagram
         INTEGER display_order
         TEXT title
         TEXT media_path
-        TEXT script_path
         TEXT learning_language
         TEXT explanation_language
         TEXT created_at
@@ -230,7 +229,6 @@ erDiagram
 | `display_order` | INTEGER     |          | グループ内でのエピソードの表示順序 |
 | `title`         | TEXT        |          | エピソードのタイトル               |
 | `media_path`    | TEXT        |          | メディアファイルのパス             |
-| `script_path`   | TEXT        |          | スクリプトファイルのパス       |
 | `learning_language` | TEXT    |          | 学習ターゲット言語 (例: 'English') |
 | `explanation_language` | TEXT  |          | 説明言語 (例: 'Japanese')        |
 | `created_at`    | TEXT        |          | 作成日時 (ISO 8601)                |
@@ -364,7 +362,7 @@ Tauriのプラグインを利用するなどしてフロントエンド側で実
 
 ## 5. ファイル管理仕様 (File Management Specification)
 
-本アプリケーションでは、ユーザーがアップロードした音声ファイルおよびスクリプト（SRTファイル）をアプリケーションの管理下にある特定のディレクトリに保存する。
+本アプリケーションでは、ユーザーがアップロードした音声ファイルをアプリケーションの管理下にある特定のディレクトリに保存する。
 データベースとファイルの整合性を保ち、管理を容易にするため、以下の仕様を定める。
 
 ### 5.1. ファイル保存場所 (Storage Location)
@@ -376,7 +374,7 @@ Tauriのプラグインを利用するなどしてフロントエンド側で実
 
 - ファイル名は固定とする。
   - **音声ファイルのパス例**: `media/{UUID}/full.mp3`
-- この`BaseDirectory.AppLocalData`からの**相対パス**を、データベースの `episodes` テーブルにある `media_path` と `script_path` カラムにそれぞれ保存する。これにより、データベースレコードと実ファイルが一意に紐づけられる。
+- この`BaseDirectory.AppLocalData`からの**相対パス**を、データベースの `episodes` テーブルにある `media_path` カラムに保存する。これにより、データベースレコードと実ファイルが一意に紐づけられる。
 - UUIDの重複チェックは、新しいエピソードを追加する際に `media/{UUID}` ディレクトリが存在するかどうかで確認する。存在する場合は、新しいUUIDを再生成する。
 
 ### 5.3. エピソード削除時の処理

--- a/doc/technical_specifications.md
+++ b/doc/technical_specifications.md
@@ -170,7 +170,7 @@ erDiagram
         INTEGER episode_group_id FK
         INTEGER display_order
         TEXT title
-        TEXT audio_path
+        TEXT media_path
         TEXT script_path
         TEXT learning_language
         TEXT explanation_language
@@ -229,7 +229,7 @@ erDiagram
 | `episode_group_id` | INTEGER  |          | `episode_groups.id`への外部キー    |
 | `display_order` | INTEGER     |          | グループ内でのエピソードの表示順序 |
 | `title`         | TEXT        |          | エピソードのタイトル               |
-| `audio_path`    | TEXT        |          | 音声ファイルのパス             |
+| `media_path`    | TEXT        |          | メディアファイルのパス             |
 | `script_path`   | TEXT        |          | スクリプトファイルのパス       |
 | `learning_language` | TEXT    |          | 学習ターゲット言語 (例: 'English') |
 | `explanation_language` | TEXT  |          | 説明言語 (例: 'Japanese')        |
@@ -370,16 +370,13 @@ Tauriのプラグインを利用するなどしてフロントエンド側で実
 ### 5.1. ファイル保存場所 (Storage Location)
 
 - 各エピソードに関連するファイル群は、TauriのFile System プラグイン (`@tauri-apps/plugin-fs`) を利用し、`BaseDirectory.AppLocalData` を基準として、エピソード固有のUUIDを持つディレクトリ内にまとめて格納する。
-- **基準パス**: `media/{UUID}/`
-- **音声ファイル**: `media/{UUID}/audios/` ディレクトリ内に格納する。これは将来的にダイアログごとの音声ファイルなどを追加で格納するため。
-- **スクリプトファイル**: `media/{UUID}/` ディレクトリ直下に格納する。
+- **基準パス**: `media/{UUID}/` ディレクトリ内に格納する。
 
 ### 5.2. ファイル命名規則 (Naming Convention)
 
 - ファイル名は固定とする。
-  - **音声ファイルのパス例**: `media/{UUID}/audios/full.mp3`
-  - **スクリプトファイルのパス例**: `media/{UUID}/script.srt`
-- この`BaseDirectory.AppLocalData`からの**相対パス**を、データベースの `episodes` テーブルにある `audio_path` と `script_path` カラムにそれぞれ保存する。これにより、データベースレコードと実ファイルが一意に紐づけられる。
+  - **音声ファイルのパス例**: `media/{UUID}/full.mp3`
+- この`BaseDirectory.AppLocalData`からの**相対パス**を、データベースの `episodes` テーブルにある `media_path` と `script_path` カラムにそれぞれ保存する。これにより、データベースレコードと実ファイルが一意に紐づけられる。
 - UUIDの重複チェックは、新しいエピソードを追加する際に `media/{UUID}` ディレクトリが存在するかどうかで確認する。存在する場合は、新しいUUIDを再生成する。
 
 ### 5.3. エピソード削除時の処理

--- a/doc/typescript_coding_style.md
+++ b/doc/typescript_coding_style.md
@@ -93,7 +93,7 @@
     type Episode = {
       readonly id: number;
       readonly title: string;
-      readonly audioPath: string;
+      readonly mediaPath: string;
       readonly createdAt: Date;
     };
     ```
@@ -138,7 +138,7 @@
     }
     
     function formatEpisode(episode: Readonly<Episode>): string {
-      return `${episode.title} - ${episode.audioPath}`;
+      return `${episode.title} - ${episode.mediaPath}`;
     }
     ```
   - 関数内でのデータ変更を防ぎ、関数の純粋性を保ちます。

--- a/src-tauri/migrations/0001-initial-tables.sql
+++ b/src-tauri/migrations/0001-initial-tables.sql
@@ -11,7 +11,7 @@ CREATE TABLE episodes (
     episode_group_id INTEGER NOT NULL,
     display_order INTEGER NOT NULL,
     title TEXT NOT NULL,
-    audio_path TEXT NOT NULL,
+    media_path TEXT NOT NULL,
     script_path TEXT NOT NULL,
     learning_language TEXT NOT NULL DEFAULT 'English',
     explanation_language TEXT NOT NULL DEFAULT 'Japanese',

--- a/src-tauri/migrations/0001-initial-tables.sql
+++ b/src-tauri/migrations/0001-initial-tables.sql
@@ -12,7 +12,6 @@ CREATE TABLE episodes (
     display_order INTEGER NOT NULL,
     title TEXT NOT NULL,
     media_path TEXT NOT NULL,
-    script_path TEXT NOT NULL,
     learning_language TEXT NOT NULL DEFAULT 'English',
     explanation_language TEXT NOT NULL DEFAULT 'Japanese',
     created_at TEXT NOT NULL,

--- a/src/lib/application/locales/en.ts
+++ b/src/lib/application/locales/en.ts
@@ -104,9 +104,6 @@ export const en = {
       },
     },
     components: {
-      audioPlayer: {
-        notSupported: 'Your browser does not support the audio tag.',
-      },
       fileSelect: {
         placeholder: 'Select a file...',
         audioFiles: 'Audio Files',

--- a/src/lib/application/locales/ja.ts
+++ b/src/lib/application/locales/ja.ts
@@ -103,9 +103,6 @@ export const ja = {
       },
     },
     components: {
-      audioPlayer: {
-        notSupported: 'お使いのブラウザは audio タグをサポートしていません。',
-      },
       fileSelect: {
         placeholder: 'ファイルを選択...',
         audioFiles: '音声ファイル',

--- a/src/lib/application/usecases/addNewEpisode.ts
+++ b/src/lib/application/usecases/addNewEpisode.ts
@@ -24,7 +24,7 @@ interface AddNewEpisodeParams {
   episodeGroupId: number;
   displayOrder: number;
   title: string;
-  audioFilePath: string;
+  mediaFilePath: string;
   scriptFilePath: string;
   tsvConfig?: TsvConfig;
 }
@@ -43,7 +43,7 @@ async function generateUniqueEpisodeFilenames(
   let uuid: string;
   do {
     const {
-      audio,
+      media: audio,
       script,
       uuid: generatedUuid,
     } = generateEpisodeFilenames(audioFilePath, scriptFilePath);
@@ -67,14 +67,21 @@ async function generateUniqueEpisodeFilenames(
  */
 export async function addNewEpisode(params: AddNewEpisodeParams): Promise<void> {
   info(`Adding new episode with params: ${JSON.stringify(params)}`);
-  const { episodeGroupId, displayOrder, title, audioFilePath, scriptFilePath, tsvConfig } = params;
+  const {
+    episodeGroupId,
+    displayOrder,
+    title,
+    mediaFilePath: audioFilePath,
+    scriptFilePath,
+    tsvConfig,
+  } = params;
   const { audioFilename, scriptFilename, uuid } = await generateUniqueEpisodeFilenames(
     audioFilePath,
     scriptFilePath
   );
   try {
-    // audioFilePath: string, scriptFilePath: string
-    const audioPath = await fileRepository.saveAudioFile(audioFilePath, uuid, audioFilename);
+    // mediaFilePath: string, scriptFilePath: string
+    const mediaPath = await fileRepository.saveAudioFile(audioFilePath, uuid, audioFilename);
     // scriptFilePathから内容を読み込む
     const scriptContent = await fileRepository.readTextFileByAbsolutePath(scriptFilePath);
     const scriptPath = await fileRepository.saveScriptFile(scriptContent, uuid, scriptFilename);
@@ -82,7 +89,7 @@ export async function addNewEpisode(params: AddNewEpisodeParams): Promise<void> 
       episodeGroupId,
       displayOrder,
       title,
-      audioPath,
+      mediaPath,
       scriptPath,
       learningLanguage: 'English',
       explanationLanguage: 'Japanese',

--- a/src/lib/application/usecases/addNewEpisode.ts
+++ b/src/lib/application/usecases/addNewEpisode.ts
@@ -84,13 +84,11 @@ export async function addNewEpisode(params: AddNewEpisodeParams): Promise<void> 
     const mediaPath = await fileRepository.saveAudioFile(audioFilePath, uuid, audioFilename);
     // scriptFilePathから内容を読み込む
     const scriptContent = await fileRepository.readTextFileByAbsolutePath(scriptFilePath);
-    const scriptPath = await fileRepository.saveScriptFile(scriptContent, uuid, scriptFilename);
     const episode = await episodeRepository.addEpisode({
       episodeGroupId,
       displayOrder,
       title,
       mediaPath,
-      scriptPath,
       learningLanguage: 'English',
       explanationLanguage: 'Japanese',
     });

--- a/src/lib/application/usecases/deleteEpisode.ts
+++ b/src/lib/application/usecases/deleteEpisode.ts
@@ -11,16 +11,16 @@ import { error } from '@tauri-apps/plugin-log';
 export async function deleteEpisode(episode: {
   readonly id: number;
   readonly title: string;
-  readonly audioPath: string;
+  readonly mediaPath: string;
 }): Promise<void> {
   try {
-    // audioPath から uuid を抽出 (例: media/uuid/audio.mp3 -> uuid)
-    const uuid = episode.audioPath.split('/')[1];
+    // mediaPath から uuid を抽出 (例: media/uuid/full.mp3 -> uuid)
+    const uuid = episode.mediaPath.split('/')[1];
     if (uuid) {
       await fileRepository.deleteEpisodeData(uuid);
     } else {
       error(
-        `Could not determine UUID for episode (id=${episode.id}: ${episode.title}) from path ${episode.audioPath}`
+        `Could not determine UUID for episode (id=${episode.id}: ${episode.title}) from path ${episode.mediaPath}`
       );
     }
 

--- a/src/lib/domain/entities/episode.ts
+++ b/src/lib/domain/entities/episode.ts
@@ -6,7 +6,7 @@ export type Episode = {
   readonly episodeGroupId: number;
   readonly displayOrder: number;
   readonly title: string;
-  readonly audioPath: string;
+  readonly mediaPath: string;
 
   readonly learningLanguage: string;
   readonly explanationLanguage: string;

--- a/src/lib/domain/services/generateEpisodeFilenames.test.ts
+++ b/src/lib/domain/services/generateEpisodeFilenames.test.ts
@@ -8,11 +8,11 @@ const MOCK_UUID = '12344678-1234-1234-1234-123446789abc';
 describe('generateEpisodeFilenames', () => {
   it('returns UUID-based filenames with original extensions for audio and script', () => {
     vi.mock('uuid', () => ({ v3: () => MOCK_UUID }));
-    const audio = 'voice.mp3';
+    const media = 'voice.mp3';
     const script = 'subtitle.srt';
-    const result = generateEpisodeFilenames(audio, script);
+    const result = generateEpisodeFilenames(media, script);
     expect(result).toEqual({
-      audio: 'full.mp3',
+      media: 'full.mp3',
       script: 'script.srt',
       uuid: MOCK_UUID,
     });
@@ -20,11 +20,11 @@ describe('generateEpisodeFilenames', () => {
 
   it('returns UUID-only filenames if there is no extension', () => {
     vi.mock('uuid', () => ({ v3: () => MOCK_UUID }));
-    const audio = 'voicefile';
+    const media = 'voicefile';
     const script = 'subtitlefile';
-    const result = generateEpisodeFilenames(audio, script);
+    const result = generateEpisodeFilenames(media, script);
     expect(result).toEqual({
-      audio: 'full',
+      media: 'full',
       script: 'script',
       uuid: MOCK_UUID,
     });
@@ -32,11 +32,11 @@ describe('generateEpisodeFilenames', () => {
 
   it('uses the last extension if there are multiple dots in the filename', () => {
     vi.mock('uuid', () => ({ v4: () => MOCK_UUID }));
-    const audio = 'foo.bar.mp3';
+    const media = 'foo.bar.mp3';
     const script = 'baz.qux.srt';
-    const result = generateEpisodeFilenames(audio, script);
+    const result = generateEpisodeFilenames(media, script);
     expect(result).toEqual({
-      audio: 'full.mp3',
+      media: 'full.mp3',
       script: 'script.srt',
       uuid: MOCK_UUID,
     });

--- a/src/lib/domain/services/generateEpisodeFilenames.ts
+++ b/src/lib/domain/services/generateEpisodeFilenames.ts
@@ -21,24 +21,24 @@ function getExtension(filename: string): string {
 }
 
 /**
- * 音声ファイル・字幕ファイルのファイルパスまたはファイル名を受け取り、
+ * 音声/動画ファイル・字幕ファイルのファイルパスまたはファイル名を受け取り、
  * UUID v4 を生成し、拡張子を付与した新しいファイル名を返します。
  *
- * @param audioPathOrName 元の音声ファイルパスまたはファイル名
+ * @param mediaPathOrName 元の音声/動画ファイルパスまたはファイル名
  * @param scriptPathOrName 元の字幕ファイルパスまたはファイル名
  * @returns 新しいファイル名とUUID
  */
 export function generateEpisodeFilenames(
-  audioPathOrName: string,
+  mediaPathOrName: string,
   scriptPathOrName: string
-): { readonly audio: string; readonly script: string; readonly uuid: string } {
+): { readonly media: string; readonly script: string; readonly uuid: string } {
   const uuid = uuidV4();
-  const audioFilename = basename(audioPathOrName);
+  const mediaFilename = basename(mediaPathOrName);
   const scriptFilename = basename(scriptPathOrName);
-  const audioExt = getExtension(audioFilename);
+  const mediaExt = getExtension(mediaFilename);
   const scriptExt = getExtension(scriptFilename);
   return {
-    audio: 'full' + audioExt,
+    media: 'full' + mediaExt,
     script: 'script' + scriptExt,
     uuid,
   };

--- a/src/lib/infrastructure/repositories/episodeRepository.ts
+++ b/src/lib/infrastructure/repositories/episodeRepository.ts
@@ -7,7 +7,7 @@ type EpisodeRow = {
   episode_group_id: number;
   display_order: number;
   title: string;
-  audio_path: string;
+  media_path: string;
   learning_language: string;
   explanation_language: string;
   created_at: string;
@@ -21,7 +21,7 @@ function mapRowToEpisode(row: EpisodeRow): Episode {
     episodeGroupId: row.episode_group_id,
     displayOrder: row.display_order,
     title: row.title,
-    audioPath: row.audio_path,
+    mediaPath: row.media_path,
     learningLanguage: row.learning_language,
     explanationLanguage: row.explanation_language,
     createdAt: new Date(row.created_at),
@@ -53,23 +53,23 @@ export const episodeRepository = {
   /**
    * 複数のグループIDに所属するすべてのエピソードの基本情報を一括で取得する（削除処理用）
    * @param groupIds 取得対象のグループIDの配列
-   * @returns エピソードの基本情報（id, title, audioPath）の配列
+   * @returns エピソードの基本情報（id, title, mediaPath）の配列
    */
   async getPartialEpisodesByGroupIds(
     groupIds: readonly number[]
   ): Promise<
-    readonly { readonly id: number; readonly title: string; readonly audioPath: string }[]
+    readonly { readonly id: number; readonly title: string; readonly mediaPath: string }[]
   > {
     if (groupIds.length === 0) {
       return [];
     }
     const db = new Database(getDatabasePath());
     const placeholders = groupIds.map(() => '?').join(',');
-    const rows = await db.select<{ id: number; title: string; audio_path: string }[]>(
-      `SELECT id, title, audio_path FROM episodes WHERE episode_group_id IN (${placeholders})`,
+    const rows = await db.select<{ id: number; title: string; media_path: string }[]>(
+      `SELECT id, title, media_path FROM episodes WHERE episode_group_id IN (${placeholders})`,
       [...groupIds]
     );
-    return rows.map((row) => ({ id: row.id, title: row.title, audioPath: row.audio_path }));
+    return rows.map((row) => ({ id: row.id, title: row.title, mediaPath: row.media_path }));
   },
 
   async getEpisodeById(id: number): Promise<Episode | null> {
@@ -85,7 +85,7 @@ export const episodeRepository = {
     episodeGroupId: number;
     displayOrder: number;
     title: string;
-    audioPath: string;
+    mediaPath: string;
     scriptPath: string;
     learningLanguage: string;
     explanationLanguage: string;
@@ -93,13 +93,13 @@ export const episodeRepository = {
     const db = new Database(getDatabasePath());
     const now = new Date().toISOString();
     await db.execute(
-      `INSERT INTO episodes (episode_group_id, display_order, title, audio_path, script_path, learning_language, explanation_language, created_at, updated_at)
+      `INSERT INTO episodes (episode_group_id, display_order, title, media_path, script_path, learning_language, explanation_language, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         params.episodeGroupId,
         params.displayOrder,
         params.title,
-        params.audioPath,
+        params.mediaPath,
         params.scriptPath,
         params.learningLanguage,
         params.explanationLanguage,

--- a/src/lib/infrastructure/repositories/episodeRepository.ts
+++ b/src/lib/infrastructure/repositories/episodeRepository.ts
@@ -86,21 +86,19 @@ export const episodeRepository = {
     displayOrder: number;
     title: string;
     mediaPath: string;
-    scriptPath: string;
     learningLanguage: string;
     explanationLanguage: string;
   }): Promise<Episode> {
     const db = new Database(getDatabasePath());
     const now = new Date().toISOString();
     await db.execute(
-      `INSERT INTO episodes (episode_group_id, display_order, title, media_path, script_path, learning_language, explanation_language, created_at, updated_at)
+      `INSERT INTO episodes (episode_group_id, display_order, title, media_path, learning_language, explanation_language, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         params.episodeGroupId,
         params.displayOrder,
         params.title,
         params.mediaPath,
-        params.scriptPath,
         params.learningLanguage,
         params.explanationLanguage,
         now,

--- a/src/lib/infrastructure/repositories/fileRepository.ts
+++ b/src/lib/infrastructure/repositories/fileRepository.ts
@@ -41,7 +41,7 @@ export const fileRepository = {
   },
 
   async saveAudioFile(absoluteFilePath: string, uuid: string, filename: string): Promise<string> {
-    const dir = `${getMediaDir()}/${uuid}/audios`;
+    const dir = `${getMediaDir()}/${uuid}`;
     const appLocalDataRelativePath = `${dir}/${filename}`;
     await invoke('copy_audio_file', { src: absoluteFilePath, dest: appLocalDataRelativePath });
     return appLocalDataRelativePath;

--- a/src/lib/infrastructure/repositories/fileRepository.ts
+++ b/src/lib/infrastructure/repositories/fileRepository.ts
@@ -1,24 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
-import {
-  BaseDirectory,
-  exists,
-  mkdir,
-  readTextFile,
-  remove,
-  writeTextFile,
-} from '@tauri-apps/plugin-fs';
-import { trace } from '@tauri-apps/plugin-log';
+import { BaseDirectory, exists, remove } from '@tauri-apps/plugin-fs';
 import { getMediaDir } from '../config';
-
-/**
- * 指定されたディレクトリが存在しなければ再帰的に作成
- */
-async function ensureDirExists(dirPath: string, baseDir: BaseDirectory): Promise<void> {
-  if (!(await exists(dirPath, { baseDir }))) {
-    trace(`Directory does not exist, creating: ${dirPath}`);
-    await mkdir(dirPath, { recursive: true, baseDir });
-  }
-}
 
 export const fileRepository = {
   /**
@@ -45,18 +27,6 @@ export const fileRepository = {
     const appLocalDataRelativePath = `${dir}/${filename}`;
     await invoke('copy_audio_file', { src: absoluteFilePath, dest: appLocalDataRelativePath });
     return appLocalDataRelativePath;
-  },
-
-  async saveScriptFile(text: string, uuid: string, filename: string): Promise<string> {
-    const dir = `${getMediaDir()}/${uuid}`;
-    await ensureDirExists(dir, BaseDirectory.AppLocalData);
-    const path = `${dir}/${filename}`;
-    await writeTextFile(path, text, { baseDir: BaseDirectory.AppLocalData });
-    return path;
-  },
-
-  async readScriptFile(relativePath: string): Promise<string> {
-    return await readTextFile(relativePath, { baseDir: BaseDirectory.AppLocalData });
   },
 
   /**

--- a/src/routes/episode-list/[groupId]/+page.svelte
+++ b/src/routes/episode-list/[groupId]/+page.svelte
@@ -77,7 +77,7 @@
         episodeGroupId: groupId,
         displayOrder: maxDisplayOrder + 1,
         title,
-        audioFilePath,
+        mediaFilePath: audioFilePath,
         scriptFilePath,
         tsvConfig,
       });

--- a/src/routes/episode/[id]/+page.ts
+++ b/src/routes/episode/[id]/+page.ts
@@ -16,9 +16,9 @@ export const load: PageLoad = async ({ params }) => {
     }
     const { isApiKeySet, settings } = await fetchSettings();
 
-    await openAudio(result.episode.audioPath);
+    await openAudio(result.episode.mediaPath);
     // Function to analyze audio data asynchronously. Caching is handled by the use case.
-    const audioInfoPromise = analyzeAudio(result.episode.audioPath);
+    const audioInfoPromise = analyzeAudio(result.episode.mediaPath);
 
     return {
       episode: result.episode,


### PR DESCRIPTION
This pull request refactors the application to unify the handling of audio and media files for episodes. The main change is replacing all references to `audio` paths with a `mediaPath` field for future support of video files. The database schema, codebase, and documentation are updated accordingly to reflect this new approach.

**Data Model & Database Changes:**
- Replaced `audio_path` and `script_path` columns in the `episodes` table with a single `media_path` column; updated SQL migration, TypeScript types, and repository logic to match. [[1]](diffhunk://#diff-8dfa1837146bd089fec46e5d3e3a551480e33e7148ff5b0b48772696dfcbcb24L14-R14) [[2]](diffhunk://#diff-d647397fb2ce405eee18a01003cce2897a2cd9c000bc08440a2c8f2d7a16722cL10-R10) [[3]](diffhunk://#diff-d647397fb2ce405eee18a01003cce2897a2cd9c000bc08440a2c8f2d7a16722cL24-R24) [[4]](diffhunk://#diff-d647397fb2ce405eee18a01003cce2897a2cd9c000bc08440a2c8f2d7a16722cL56-R72) [[5]](diffhunk://#diff-d647397fb2ce405eee18a01003cce2897a2cd9c000bc08440a2c8f2d7a16722cL88-R101) [[6]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L173-R173) [[7]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L232-R231) [[8]](diffhunk://#diff-bb26d0ada470a557411436dee106b756aa9493b6dc23d6a60a730a9ae8910328L96-R96) [[9]](diffhunk://#diff-abeef342b96ee79c55e5b8a8adb98357a2912c1fd22f441fbb8ed5a374e41128L9-R9)

**File Management & Repository Updates:**
- Refactored file save logic to use `mediaPath` for all episode media (audio/video), removed script file handling from the repository, and simplified directory structure for episode files. [[1]](diffhunk://#diff-0e990b2847cc1a3f5b6d22d4acfb3315292b071a086d64553a28f6c6e90bc93fL2-L22) [[2]](diffhunk://#diff-0e990b2847cc1a3f5b6d22d4acfb3315292b071a086d64553a28f6c6e90bc93fL44-L61) [[3]](diffhunk://#diff-a97528944346713c6325d02695159b9970374d58caa94823085c84dcc9ef0a74L27-R27) [[4]](diffhunk://#diff-a97528944346713c6325d02695159b9970374d58caa94823085c84dcc9ef0a74L46-R46) [[5]](diffhunk://#diff-a97528944346713c6325d02695159b9970374d58caa94823085c84dcc9ef0a74L70-R91) [src/routes/episode-list/[groupId]/+page.svelteL80-R80](diffhunk://#diff-b580de1281047717dbfe76ba19cfc09bc605f0a6c0a7c949862e35a40514b0b1L80-R80))

**Service & Utility Changes:**
- Updated filename generation utilities and related tests to use `media` instead of `audio`, supporting both audio and video files under a unified naming scheme. [[1]](diffhunk://#diff-4678ce89149e3a8ac80303adea1c0920231f1667857d7dab74c9a13657006e56L24-R41) [[2]](diffhunk://#diff-0d32f10e6706015e6c778db6977ac060fc800158113ffa06022e9d8f5e368e28L11-R39)

**Frontend & Use Case Adjustments:**
- Updated all usages and function parameters from `audioPath` to `mediaPath` throughout the codebase, including episode deletion, loading, and display logic, as well as TypeScript type annotations and documentation examples. [[1]](diffhunk://#diff-5930372b1965a653a569bbacf9c90bb9a572000d42668a5963d8e37a865fa3cbL14-R23) [src/routes/episode/[id]/+page.tsL19-R21](diffhunk://#diff-ace15da6d7d00e762655b159f0f9c31e800708b01b98b88f33100d32de225506L19-R21), [[2]](diffhunk://#diff-bb26d0ada470a557411436dee106b756aa9493b6dc23d6a60a730a9ae8910328L141-R141)

**Documentation Updates:**
- Revised technical specifications to describe the new `media_path` field and simplified file storage structure, removing references to separate audio and script files.

**Minor:**
- Removed unused `audioPlayer` localization entries. [[1]](diffhunk://#diff-083c5f6756fa8f4fcad9fca62b4c73ff0b5199b87d2fb0d775b613c9057075beL107-L109) [[2]](diffhunk://#diff-c7f454c8811c76fcb01a22679bf8bd75ca48cd1aec0e86d63c6a984c49ce1d31L106-L108)