### PR TITLE
Remove PART_OF_SPEECH_OPTIONS for support of various languages in future

### DIFF
--- a/doc/prompt.md
+++ b/doc/prompt.md
@@ -19,7 +19,7 @@ Your analysis should result in the following top-level fields:
 
 For each item identified from the `TARGET_LINE`, you must provide:
 a.  `expression`: The extracted word or phrase. Use the base form (lemma) for verbs.
-b.  `partOfSpeech`: The part of speech of the expression.
+b.  `partOfSpeech`: The part of speech or category of the expression, **written in the `EXPLANATION_LANGUAGE`**. The value should be a common linguistic term (e.g., "Noun", "Verb", "Idiom," etc. in the appropriate translation) that best describes the extracted expression.
 c.  `contextualDefinition`: A concise, contextual definition in the `EXPLANATION_LANGUAGE`. This definition should be a brief explanation of the **meaning of the extracted expression itself**, **without** any overtly explanatory or redundant phrasing.
 d.  `coreMeaning`: A detailed, core meaning explanation in the `EXPLANATION_LANGUAGE`. This explanation must describe the fundamental, general meaning of the word or phrase, independent of the specific sentence context.
 e.  `exampleSentence`: The full `sentence` from the top-level, but with the specific `expression` for this item highlighted using `<b>` tags.
@@ -34,12 +34,12 @@ e.  `exampleSentence`: The full `sentence` from the top-level, but with the spec
 * **Principle of Direct Definition**: This is the most important rule. The `contextualDefinition` and `coreMeaning` fields **must always be a direct definition of the exact text extracted in the `expression` field**.
 * **Filtering**: Do NOT extract extremely basic, common words (e.g., CEFR A1 level). Focus on words and phrases an intermediate learner would find challenging.
 * **Comprehensive Identification**: You must identify both multi-word units (phrasal verbs, idioms, etc.) and important individual words from the `TARGET_LINE`. When you identify a phrase, also consider extracting its key component words separately if they are likely to be unknown to an intermediate learner.
-* **Part-of-Speech Selection**: The value for the `part_of_speech` field MUST be chosen from the list provided in `PART_OF_SPEECH_OPTIONS`.
+* **Part-of-Speech Language**: The value for the `partOfSpeech` field **MUST be written in the `EXPLANATION_LANGUAGE`** (the learner's native language). Use a common linguistic term that an average language learner would understand (e.g., 名詞, 動詞, 慣用句).
 * **Empty Result**: If no relevant expressions are found, the "items" array should be empty, but the `sentence`, `translation`, and `explanation` fields should still be provided.
 * **[CRITICAL] Rule for `sentence` and `exampleSentence` Construction**: Your construction process must follow two steps:
   1.  **Generate the Base `sentence`**: First, you must construct a single, natural, and grammatically complete sentence from the `TARGET_LINE` and its surrounding `CONVERSATION_LOG`. If the `TARGET_LINE` is already a complete sentence, use it. If it is a fragment, combine it with the necessary preceding or succeeding lines. **This complete sentence is the value for the top-level `sentence` field.**
   2.  **Generate each `exampleSentence`**: For each vocabulary item in the `items` array, take the base `sentence` generated in Step 1 and enclose the corresponding `expression` for that item within `<b>` tags. This highlighted version is the value for the `exampleSentence` field within that item.
-* **Language Fidelity**: All user-facing explanations (`translation`, `explanation`, `contextualDefinition`, `coreMeaning`) **MUST** be written in the specified `EXPLANATION_LANGUAGE`.
+* **Language Fidelity**: All user-facing explanations (`translation`, `explanation`, `contextualDefinition`, `coreMeaning`, and `partOfSpeech`) **MUST** be written in the specified `EXPLANATION_LANGUAGE`.
 * **Negation Handling**: When extracting a verb from a negative construction (e.g., "didn't finish"), extract the base form (`finish`). The explanations for the verb should define the verb itself, not the negation. The role of the negation should be covered in the main `explanation` field.
 
 # Example
@@ -49,7 +49,6 @@ Here is an example of how to apply the rules.
 ## Scenario
 
 - A user is learning **English** and wants explanations in **Japanese**. (`EXPLANATION_LANGUAGE` is `Japanese`)
-- The `PART_OF_SPEECH_OPTIONS` are `["Noun", "Pronoun", "Verb", "Adjective", "Adverb", "Preposition", "Conjunction", "Interjection", "Determiner", "Phrasal Verb", "Idiom", "Collocation", "Expression"]`.
 - The `CONVERSATION_LOG` is:
   > Did you finish the report for the meeting
   > Not yet
@@ -68,42 +67,33 @@ I had to pull an all-nighter to get it done, but it's almost there.
 それを終わらせるために徹夜しなければなりませんでしたが、もうほとんど出来ています。
 
 **explanation**
-この文は、2つの節が接続詞 'but' で繋がれた構造をしています。前半の 'I had to pull an all-nighter to get it done' は、「～するために徹夜しなければならなかった」という意味です。後半の 'it's almost there' は「もうすぐだ」「ゴールは近い」という意味の口語表現で、ここではレポートの完成が間近であることを示しています。これらを組み合わせることで、全体の意味が形成されます。
+この文は、2つの節が接続詞 'but' で繋がれた構造をしています。前半の 'I had to pull an all-nighter to get it done' は、「～するために徹夜しなければならなかった」という意味です。'had to' は義務を表し、'to get it done' は目的を表す不定詞句です。'pull an all-nighter' が「徹夜する」という重要な慣用句です。後半の 'it's almost there' は「もうすぐだ」「ゴールは近い」という意味の口語表現で、ここではレポートの完成が間近であることを示しています。これらを組み合わせることで、全体の意味が形成されます。
 
 **items**:
 
 - **Item 1**:
   - **expression**: pull an all-nighter
-  - **partOfSpeech**: Idiom
+  - **partOfSpeech**: 慣用句
   - **contextualDefinition**: 徹夜する
   - **coreMeaning**: 一晩中、特に勉強や仕事のために起きていること。睡眠をとらずに夜を明かすという行為そのものを指す表現。
-  - **exampleSentence**: I had to \<b\>pull an all-nighter\</b\> to get it done, but it's almost there.
+  - **exampleSentence**: I had to <b>pull an all-nighter</b> to get it done, but it's almost there.
 - **Item 2**:
   - **expression**: get something done
-  - **partOfSpeech**: Expression
+  - **partOfSpeech**: 表現
   - **contextualDefinition**: ～を終わらせる、完成させる
   - **coreMeaning**: あるタスクや仕事を完了させる、または誰かに完了させることを示す使役的な表現。ここでは自分自身で終わらせることを指す。
-  - **exampleSentence**: I had to pull an all-nighter to \<b\>get it done\</b\>, but it's almost there.
+  - **exampleSentence**: I had to pull an all-nighter to <b>get it done</b>, but it's almost there.
+- **Item 3**:
+  - **expression**: almost there
+  - **partOfSpeech**: 表現
+  - **contextualDefinition**: もうほとんど出来ている、完成間近である
+  - **coreMeaning**: 物理的な目的地や、目標達成まであと少しのところまで来ている状態を指す口語的な表現。
+  - **exampleSentence**: I had to pull an all-nighter to get it done, but it's <b>almost there</b>.
 
 # Input
 
 * **LEARNING_LANGUAGE**: English
 * **EXPLANATION_LANGUAGE**: Japanese
-* **PART_OF_SPEECH_OPTIONS**: [
-  "Noun",
-  "Pronoun",
-  "Verb",
-  "Adjective",
-  "Adverb",
-  "Preposition",
-  "Conjunction",
-  "Interjection",
-  "Determiner",
-  "Phrasal Verb",
-  "Idiom",
-  "Collocation",
-  "Expression"
-  ]
 * **CONVERSATION_LOG**:
 ```
 Did you finish the report for the meeting?
@@ -129,21 +119,21 @@ This section is **not** included in the actual prompt, as we use the Structured 
   "items": [
     {
       "expression": "pull an all-nighter",
-      "partOfSpeech": "Idiom",
+      "partOfSpeech": "慣用句",
       "contextualDefinition": "徹夜する",
       "coreMeaning": "一晩中、特に勉強や仕事のために起きていること。睡眠をとらずに夜を明かすという行為そのものを指す表現。",
       "exampleSentence": "I had to <b>pull an all-nighter</b> to get it done, but it's almost there."
     },
     {
       "expression": "get something done",
-      "partOfSpeech": "Expression",
+      "partOfSpeech": "表現",
       "contextualDefinition": "～を終わらせる、完成させる",
       "coreMeaning": "あるタスクや仕事を完了させる、または誰かに完了させることを示す使役的な表現。ここでは自分自身で終わらせることを指す。",
       "exampleSentence": "I had to pull an all-nighter to <b>get it done</b>, but it's almost there."
     },
     {
       "expression": "almost there",
-      "partOfSpeech": "Idiom",
+      "partOfSpeech": "表現",
       "contextualDefinition": "もうほとんど出来ている、完成間近である",
       "coreMeaning": "物理的な目的地や、目標達成まであと少しのところまで来ている状態を指す口語的な表現。",
       "exampleSentence": "I had to pull an all-nighter to get it done, but it's <b>almost there</b>."

--- a/src-tauri/src/llm.rs
+++ b/src-tauri/src/llm.rs
@@ -12,7 +12,7 @@ pub struct SentenceMiningItem {
     pub expression: String,
 
     #[schema(
-        description = "The part of speech or type of the expression, chosen from the predefined PART_OF_SPEECH_OPTIONS list provided in the input."
+        description = "The part of speech or type of the expression, written in the learner's native language. The value should be a common linguistic term that best describes the extracted expression."
     )]
     #[serde(rename = "partOfSpeech")]
     pub part_of_speech: String,
@@ -63,7 +63,6 @@ pub struct SentenceMiningResult {
 fn build_prompt(
     learning_language: &str,
     explanation_language: &str,
-    part_of_speech_options: &str,
     context: &str,
     target_sentence: &str,
 ) -> String {
@@ -91,7 +90,7 @@ Your analysis should result in the following top-level fields:
 
 For each item identified from the `TARGET_LINE`, you must provide:
 a.  `expression`: The extracted word or phrase. Use the base form (lemma) for verbs.
-b.  `partOfSpeech`: The part of speech of the expression.
+b.  `partOfSpeech`: The part of speech or category of the expression, **written in the `EXPLANATION_LANGUAGE`**. The value should be a common linguistic term (e.g., "Noun", "Verb", "Idiom," etc. in the appropriate translation) that best describes the extracted expression.
 c.  `contextualDefinition`: A concise, contextual definition in the `EXPLANATION_LANGUAGE`. This definition should be a brief explanation of the **meaning of the extracted expression itself**, **without** any overtly explanatory or redundant phrasing.
 d.  `coreMeaning`: A detailed, core meaning explanation in the `EXPLANATION_LANGUAGE`. This explanation must describe the fundamental, general meaning of the word or phrase, independent of the specific sentence context.
 e.  `exampleSentence`: The full `sentence` from the top-level, but with the specific `expression` for this item highlighted using `<b>` tags.
@@ -106,12 +105,12 @@ e.  `exampleSentence`: The full `sentence` from the top-level, but with the spec
 * **Principle of Direct Definition**: This is the most important rule. The `contextualDefinition` and `coreMeaning` fields **must always be a direct definition of the exact text extracted in the `expression` field**.
 * **Filtering**: Do NOT extract extremely basic, common words (e.g., CEFR A1 level). Focus on words and phrases an intermediate learner would find challenging.
 * **Comprehensive Identification**: You must identify both multi-word units (phrasal verbs, idioms, etc.) and important individual words from the `TARGET_LINE`. When you identify a phrase, also consider extracting its key component words separately if they are likely to be unknown to an intermediate learner.
-* **Part-of-Speech Selection**: The value for the `part_of_speech` field MUST be chosen from the list provided in `PART_OF_SPEECH_OPTIONS`.
+* **Part-of-Speech Language**: The value for the `partOfSpeech` field **MUST be written in the `EXPLANATION_LANGUAGE`** (the learner's native language). Use a common linguistic term that an average language learner would understand (e.g., 名詞, 動詞, 慣用句).
 * **Empty Result**: If no relevant expressions are found, the "items" array should be empty, but the `sentence`, `translation`, and `explanation` fields should still be provided.
 * **[CRITICAL] Rule for `sentence` and `exampleSentence` Construction**: Your construction process must follow two steps:
   1.  **Generate the Base `sentence`**: First, you must construct a single, natural, and grammatically complete sentence from the `TARGET_LINE` and its surrounding `CONVERSATION_LOG`. If the `TARGET_LINE` is already a complete sentence, use it. If it is a fragment, combine it with the necessary preceding or succeeding lines. **This complete sentence is the value for the top-level `sentence` field.**
   2.  **Generate each `exampleSentence`**: For each vocabulary item in the `items` array, take the base `sentence` generated in Step 1 and enclose the corresponding `expression` for that item within `<b>` tags. This highlighted version is the value for the `exampleSentence` field within that item.
-* **Language Fidelity**: All user-facing explanations (`translation`, `explanation`, `contextualDefinition`, `coreMeaning`) **MUST** be written in the specified `EXPLANATION_LANGUAGE`.
+* **Language Fidelity**: All user-facing explanations (`translation`, `explanation`, `contextualDefinition`, `coreMeaning`, and `partOfSpeech`) **MUST** be written in the specified `EXPLANATION_LANGUAGE`.
 * **Negation Handling**: When extracting a verb from a negative construction (e.g., "didn't finish"), extract the base form (`finish`). The explanations for the verb should define the verb itself, not the negation. The role of the negation should be covered in the main `explanation` field.
 
 # Example
@@ -121,7 +120,6 @@ Here is an example of how to apply the rules.
 ## Scenario
 
 - A user is learning **English** and wants explanations in **Japanese**. (`EXPLANATION_LANGUAGE` is `Japanese`)
-- The `PART_OF_SPEECH_OPTIONS` are `["Noun", "Pronoun", "Verb", "Adjective", "Adverb", "Preposition", "Conjunction", "Interjection", "Determiner", "Phrasal Verb", "Idiom", "Collocation", "Expression"]`.
 - The `CONVERSATION_LOG` is:
   > Did you finish the report for the meeting
   > Not yet
@@ -140,28 +138,33 @@ I had to pull an all-nighter to get it done, but it's almost there.
 それを終わらせるために徹夜しなければなりませんでしたが、もうほとんど出来ています。
 
 **explanation**
-この文は、2つの節が接続詞 'but' で繋がれた構造をしています。前半の 'I had to pull an all-nighter to get it done' は、「～するために徹夜しなければならなかった」という意味です。後半の 'it's almost there' は「もうすぐだ」「ゴールは近い」という意味の口語表現で、ここではレポートの完成が間近であることを示しています。これらを組み合わせることで、全体の意味が形成されます。
+この文は、2つの節が接続詞 'but' で繋がれた構造をしています。前半の 'I had to pull an all-nighter to get it done' は、「～するために徹夜しなければならなかった」という意味です。'had to' は義務を表し、'to get it done' は目的を表す不定詞句です。'pull an all-nighter' が「徹夜する」という重要な慣用句です。後半の 'it's almost there' は「もうすぐだ」「ゴールは近い」という意味の口語表現で、ここではレポートの完成が間近であることを示しています。これらを組み合わせることで、全体の意味が形成されます。
 
 **items**:
 
 - **Item 1**:
   - **expression**: pull an all-nighter
-  - **partOfSpeech**: Idiom
+  - **partOfSpeech**: 慣用句
   - **contextualDefinition**: 徹夜する
   - **coreMeaning**: 一晩中、特に勉強や仕事のために起きていること。睡眠をとらずに夜を明かすという行為そのものを指す表現。
   - **exampleSentence**: I had to <b>pull an all-nighter</b> to get it done, but it's almost there.
 - **Item 2**:
   - **expression**: get something done
-  - **partOfSpeech**: Expression
+  - **partOfSpeech**: 表現
   - **contextualDefinition**: ～を終わらせる、完成させる
   - **coreMeaning**: あるタスクや仕事を完了させる、または誰かに完了させることを示す使役的な表現。ここでは自分自身で終わらせることを指す。
   - **exampleSentence**: I had to pull an all-nighter to <b>get it done</b>, but it's almost there.
+- **Item 3**:
+  - **expression**: almost there
+  - **partOfSpeech**: 表現
+  - **contextualDefinition**: もうほとんど出来ている、完成間近である
+  - **coreMeaning**: 物理的な目的地や、目標達成まであと少しのところまで来ている状態を指す口語的な表現。
+  - **exampleSentence**: I had to pull an all-nighter to get it done, but it's <b>almost there</b>.
 
 # Input
 
 * **LEARNING_LANGUAGE**:  {learning_language}
 * **EXPLANATION_LANGUAGE**: {explanation_language}
-* **PART_OF_SPEECH_OPTIONS**: [{part_of_speech_options}]
 * **CONVERSATION_LOG**:
 ```
 {context}
@@ -179,19 +182,12 @@ pub async fn analyze_sentence_with_llm(
     api_key: String,
     learning_language: String,
     explanation_language: String,
-    part_of_speech_options: Vec<String>,
     context: String,
     target_sentence: String,
 ) -> Result<SentenceMiningResult, String> {
-    let part_of_speech_options = part_of_speech_options
-        .into_iter()
-        .map(|s| format!("\"{}\"", s.trim()))
-        .collect::<Vec<_>>()
-        .join(", ");
     let prompt = build_prompt(
         &learning_language,
         &explanation_language,
-        &part_of_speech_options,
         &context,
         &target_sentence,
     );

--- a/src/lib/application/usecases/analyzeDialogueForMining.ts
+++ b/src/lib/application/usecases/analyzeDialogueForMining.ts
@@ -6,23 +6,6 @@ import { dialogueRepository } from '$lib/infrastructure/repositories/dialogueRep
 import { llmRepository } from '$lib/infrastructure/repositories/llmRepository';
 import { sentenceCardRepository } from '$lib/infrastructure/repositories/sentenceCardRepository';
 
-// とりあえず英語のみサポートするので定数
-const PART_OF_SPEECH_OPTIONS: readonly string[] = [
-  'Noun',
-  'Pronoun',
-  'Verb',
-  'Adjective',
-  'Adverb',
-  'Preposition',
-  'Conjunction',
-  'Interjection',
-  'Determiner',
-  'Phrasal Verb',
-  'Idiom',
-  'Collocation',
-  'Expression',
-];
-
 async function ensureApiKey(): Promise<string> {
   const apiKey = apiKeyStore.gemini.value;
   if (apiKey !== null) {
@@ -78,7 +61,6 @@ export async function analyzeDialogueForMining(
     apiKey,
     'English',
     'Japanese',
-    PART_OF_SPEECH_OPTIONS,
     contextSentences,
     targetSentence
   );

--- a/src/lib/infrastructure/repositories/llmRepository.ts
+++ b/src/lib/infrastructure/repositories/llmRepository.ts
@@ -7,19 +7,17 @@ export const llmRepository = {
     apiKey: string,
     learningLanguage: string,
     explanationLanguage: string,
-    partOfSpeechOptions: readonly string[],
     context: string,
     targetSentence: string
   ): Promise<SentenceAnalysisResult> {
     info(
-      `Analyzing sentence: ${targetSentence}, ${learningLanguage} => ${explanationLanguage}, partOfSpeech: [${partOfSpeechOptions.join(', ')}], context: ${context}`
+      `Analyzing sentence: ${targetSentence}, ${learningLanguage} => ${explanationLanguage}, context: ${context}`
     );
 
     const response = await invoke<SentenceAnalysisResult>('analyze_sentence_with_llm', {
       apiKey,
       learningLanguage,
       explanationLanguage,
-      partOfSpeechOptions,
       context,
       targetSentence,
     });


### PR DESCRIPTION
This pull request updates both the documentation and the implementation for sentence mining to ensure that the part of speech (POS) for extracted expressions is always written in the learner's native language (the `EXPLANATION_LANGUAGE`), using common linguistic terms. It removes the need to pass a predefined list of POS options from the frontend, simplifies the prompt construction, and updates all examples and logic to reflect these changes.

The most important changes are:

**Prompt and Output Format Updates:**
- The `partOfSpeech` field for each extracted item must now be written in the learner's native language, using a common linguistic term, and not selected from an English options list. This is enforced in both the documentation (`doc/prompt.md`) and the backend prompt template (`src-tauri/src/llm.rs`). [[1]](diffhunk://#diff-f972e6177f85adaf67262ac67aad0aa79efa01eb5964ca6a916792989d87b37eL22-R22) [[2]](diffhunk://#diff-f972e6177f85adaf67262ac67aad0aa79efa01eb5964ca6a916792989d87b37eL37-R42) [[3]](diffhunk://#diff-5e361afebb93ccc46f332e641dac33c96198958d4dd46efd7ecb752e0b15ac08L94-R93) [[4]](diffhunk://#diff-5e361afebb93ccc46f332e641dac33c96198958d4dd46efd7ecb752e0b15ac08L109-R113)
- All user-facing explanations, including `partOfSpeech`, must be in the `EXPLANATION_LANGUAGE`. [[1]](diffhunk://#diff-f972e6177f85adaf67262ac67aad0aa79efa01eb5964ca6a916792989d87b37eL37-R42) [[2]](diffhunk://#diff-5e361afebb93ccc46f332e641dac33c96198958d4dd46efd7ecb752e0b15ac08L109-R113)

**Documentation and Example Updates:**
- All examples in the documentation and prompt templates now show `partOfSpeech` values in Japanese (e.g., "慣用句", "表現") instead of English ("Idiom", "Expression"), and an additional example item ("almost there") is included. [[1]](diffhunk://#diff-f972e6177f85adaf67262ac67aad0aa79efa01eb5964ca6a916792989d87b37eL71-L106) [[2]](diffhunk://#diff-f972e6177f85adaf67262ac67aad0aa79efa01eb5964ca6a916792989d87b37eL132-R136) [[3]](diffhunk://#diff-5e361afebb93ccc46f332e641dac33c96198958d4dd46efd7ecb752e0b15ac08L143-L164)
- The reference to `PART_OF_SPEECH_OPTIONS` in both the doc and prompt template has been removed, clarifying that the POS should not be chosen from a static English list. [[1]](diffhunk://#diff-f972e6177f85adaf67262ac67aad0aa79efa01eb5964ca6a916792989d87b37eL52) [[2]](diffhunk://#diff-f972e6177f85adaf67262ac67aad0aa79efa01eb5964ca6a916792989d87b37eL71-L106) [[3]](diffhunk://#diff-5e361afebb93ccc46f332e641dac33c96198958d4dd46efd7ecb752e0b15ac08L124) [[4]](diffhunk://#diff-5e361afebb93ccc46f332e641dac33c96198958d4dd46efd7ecb752e0b15ac08L143-L164)

**Backend and API Changes:**
- The backend (`src-tauri/src/llm.rs`) no longer accepts or processes a `part_of_speech_options` parameter. All related code and function parameters have been removed for simplicity. [[1]](diffhunk://#diff-5e361afebb93ccc46f332e641dac33c96198958d4dd46efd7ecb752e0b15ac08L66) [[2]](diffhunk://#diff-5e361afebb93ccc46f332e641dac33c96198958d4dd46efd7ecb752e0b15ac08L182-L194)
- The prompt construction and LLM invocation logic have been updated to match the new requirements, ensuring the prompt does not reference a POS options list. [[1]](diffhunk://#diff-5e361afebb93ccc46f332e641dac33c96198958d4dd46efd7ecb752e0b15ac08L66) [[2]](diffhunk://#diff-5e361afebb93ccc46f332e641dac33c96198958d4dd46efd7ecb752e0b15ac08L182-L194)

**Frontend Simplification:**
- The frontend (`usecases/analyzeDialogueForMining.ts`, `llmRepository.ts`) no longer defines or passes a `PART_OF_SPEECH_OPTIONS` list to the backend, and all related code has been removed. Logging and function signatures have been updated accordingly. [[1]](diffhunk://#diff-60e1245e84f937b041645612722022f83fdc7ef5884524425a407974f3110df4L9-L25) [[2]](diffhunk://#diff-60e1245e84f937b041645612722022f83fdc7ef5884524425a407974f3110df4L81) [[3]](diffhunk://#diff-20b036f1abb72939ff4760e869b6cd86c3dcf29bb4aff057c4f55ab6c8fe4a93L10-L22)

**Clarification and Enrichment of Explanations:**
- The sample explanations in both the documentation and code now more clearly break down sentence structure and highlight the importance of idiomatic expressions, improving guidance for both users and the LLM. [[1]](diffhunk://#diff-f972e6177f85adaf67262ac67aad0aa79efa01eb5964ca6a916792989d87b37eL71-L106) [[2]](diffhunk://#diff-5e361afebb93ccc46f332e641dac33c96198958d4dd46efd7ecb752e0b15ac08L143-L164)

These changes ensure that the system produces more learner-friendly, localized explanations and simplifies both the API and prompt structure.