### PR TITLE
refactor: Remove deleted_at field from database schema and related code

### DIFF
--- a/doc/technical_specifications.md
+++ b/doc/technical_specifications.md
@@ -206,7 +206,7 @@ Infrastructure が Domain に依存する方向になっているが、Clean Arc
 ### 共通仕様
 
 - `id` は UUID 文字列（TEXT）。
-- `updated_at` と `deleted_at` は ISO 8601 文字列。INSERT 時に `updated_at` を現在時刻で設定し、削除時に `deleted_at` を現在時刻で設定する。`deleted_at` が NULL なら未削除扱い。
+- `updated_at` は ISO 8601 文字列。INSERT 時に `updated_at` を現在時刻で設定する。
 - `content` カラムに JSON 文字列で可変フィールドを格納し、テーブルスキーマ変更を最小化する。
 - 外部キー制約は付与しない（論理的なリレーションは維持）。
 
@@ -221,14 +221,12 @@ erDiagram
         TEXT group_type
         TEXT content
         TEXT updated_at
-        TEXT deleted_at
     }
     EPISODES {
         TEXT id PK
         TEXT episode_group_id
         TEXT content
         TEXT updated_at
-        TEXT deleted_at
     }
     SUBTITLE_LINES {
         TEXT id PK
@@ -236,7 +234,6 @@ erDiagram
         INTEGER sequence_number
         TEXT content
         TEXT updated_at
-        TEXT deleted_at
     }
     SENTENCE_CARDS {
         TEXT id PK
@@ -244,7 +241,6 @@ erDiagram
         TEXT content
         TEXT status
         TEXT updated_at
-        TEXT deleted_at
     }
 
     EPISODE_GROUPS ||--o{ EPISODE_GROUPS : "parent_group_id"
@@ -264,7 +260,6 @@ erDiagram
 | `display_order`   | INTEGER |          | 表示順序                                            |
 | `group_type`      | TEXT    |          | `album` (エピソード格納可) / `folder` (サブグループ専用) |
 | `updated_at`      | TEXT    |          | 最終更新時刻 (ISO 8601)                             |
-| `deleted_at`      | TEXT    | ●        | 削除時刻 (ISO 8601)。NULL なら未削除                |
 
 ### 2.2. `episodes` テーブル
 エピソード（音声コンテンツとスクリプトのセット）を管理する。
@@ -275,7 +270,6 @@ erDiagram
 | `episode_group_id`   | TEXT |          | 論理的に `episode_groups.id` を参照                                   |
 | `content`            | TEXT |          | JSON 文字列。`{ title, mediaPath, learningLanguage, explanationLanguage }` |
 | `updated_at`         | TEXT |          | 最終更新時刻 (ISO 8601)                                               |
-| `deleted_at`         | TEXT | ●        | 削除時刻 (ISO 8601)。NULL なら未削除                                  |
 
 ### 2.3. `subtitle_lines` テーブル（旧 `dialogues`）
 スクリプト内の各セリフを管理する。`sequence_number` は startTimeMs 順の 1 始まり連番。
@@ -287,9 +281,8 @@ erDiagram
 | `sequence_number`   | INTEGER |          | セリフ順。startTimeMs 昇順で 1 始まり                                               |
 | `content`           | TEXT    |          | JSON 文字列。`{ startTimeMs, endTimeMs, originalText, correctedText, translation, explanation, sentence, hidden }` |
 | `updated_at`        | TEXT    |          | 最終更新時刻 (ISO 8601)                                                              |
-| `deleted_at`        | TEXT    | ●        | 削除時刻 (ISO 8601)。NULL なら未削除                                                 |
 
-`hidden` は論理的な非表示フラグで、`deleted_at` とは別に管理する（`deleted_at` が設定された行は復元不可の削除扱い）。
+`hidden` は論理的な非表示フラグで、削除とは別に管理する。
 
 ### 2.4. `sentence_cards` テーブル
 Sentence Mining で生成されたカードを管理する。
@@ -301,7 +294,6 @@ Sentence Mining で生成されたカードを管理する。
 | `content`           | TEXT |          | JSON 文字列。`{ partOfSpeech, expression, sentence, contextualDefinition, coreMeaning, createdAt }` |
 | `status`            | TEXT |          | `active` / `suspended` / `cache` などの状態                                          |
 | `updated_at`        | TEXT |          | 最終更新時刻 (ISO 8601)                                                              |
-| `deleted_at`        | TEXT | ●        | 削除時刻 (ISO 8601)。NULL なら未削除                                                 |
 
 ---
 

--- a/src-tauri/migrations/0001-initial-tables.sql
+++ b/src-tauri/migrations/0001-initial-tables.sql
@@ -4,29 +4,25 @@ CREATE TABLE episode_groups (
     content TEXT NOT NULL,
     display_order INTEGER NOT NULL,
     group_type TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    deleted_at TEXT DEFAULT NULL
+    updated_at TEXT NOT NULL
 );
 CREATE TABLE episodes (
     id TEXT PRIMARY KEY,
     episode_group_id TEXT NOT NULL,
     content TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    deleted_at TEXT DEFAULT NULL
+    updated_at TEXT NOT NULL
 );
 CREATE TABLE subtitle_lines (
     id TEXT PRIMARY KEY,
     episode_id TEXT NOT NULL,
     sequence_number INTEGER NOT NULL,
     content TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    deleted_at TEXT DEFAULT NULL
+    updated_at TEXT NOT NULL
 );
 CREATE TABLE sentence_cards (
     id TEXT PRIMARY KEY,
     subtitle_line_id TEXT NOT NULL,
     content TEXT NOT NULL,
     status TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    deleted_at TEXT DEFAULT NULL
+    updated_at TEXT NOT NULL
 );

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -131,11 +131,11 @@ See: [src-tauri/AGENTS.md](../src-tauri/AGENTS.md) for full details.
 ## Database overview
 
 - Tables
-  - `episode_groups`: hierarchical groups. Fields: `id` (UUID, PK), `parent_group_id` (nullable), `content` (JSON: `{ name }`), `display_order`, `group_type` (`album`|`folder`), `updated_at`, `deleted_at`.
-  - `episodes`: episodes (audio + transcript). Fields: `id` (UUID, PK), `episode_group_id`, `content` (JSON: `{ title, mediaPath, learningLanguage, explanationLanguage }`), `updated_at`, `deleted_at`.
-  - `subtitle_lines` (old `dialogues`): transcript lines. Fields: `id` (UUID, PK), `episode_id`, `sequence_number` (1-based order by startTimeMs), `content` (JSON: `{ startTimeMs, endTimeMs, originalText, correctedText, translation, explanation, sentence, hidden }`), `updated_at`, `deleted_at`.
-  - `sentence_cards`: sentence-mining results. Fields: `id` (UUID, PK), `subtitle_line_id`, `content` (JSON: `{ partOfSpeech, expression, sentence, contextualDefinition, coreMeaning, createdAt }`), `status` (`active`|`suspended`|`cache` etc.), `updated_at`, `deleted_at`.
-- Common rules: `id` is UUID string; timestamps are ISO 8601; `content` holds flexible JSON; no foreign key constraints; `deleted_at` NULL means active.
+  - `episode_groups`: hierarchical groups. Fields: `id` (UUID, PK), `parent_group_id` (nullable), `content` (JSON: `{ name }`), `display_order`, `group_type` (`album`|`folder`), `updated_at`.
+  - `episodes`: episodes (audio + transcript). Fields: `id` (UUID, PK), `episode_group_id`, `content` (JSON: `{ title, mediaPath, learningLanguage, explanationLanguage }`), `updated_at`.
+  - `subtitle_lines` (old `dialogues`): transcript lines. Fields: `id` (UUID, PK), `episode_id`, `sequence_number` (1-based order by startTimeMs), `content` (JSON: `{ startTimeMs, endTimeMs, originalText, correctedText, translation, explanation, sentence, hidden }`), `updated_at`.
+  - `sentence_cards`: sentence-mining results. Fields: `id` (UUID, PK), `subtitle_line_id`, `content` (JSON: `{ partOfSpeech, expression, sentence, contextualDefinition, coreMeaning, createdAt }`), `status` (`active`|`suspended`|`cache` etc.), `updated_at`.
+- Common rules: `id` is UUID string; timestamps are ISO 8601; `content` holds flexible JSON; no foreign key constraints.
 - Use the DB as the single source of truth; front-end stores remain transient UI state only.
 
 See: `src-tauri/migrations/` for authoritative schema details.

--- a/src/integration-tests/lib/database.ts
+++ b/src/integration-tests/lib/database.ts
@@ -27,8 +27,8 @@ export async function insertEpisodeGroup(params: {
   const now = new Date().toISOString();
   const db = new Database(DATABASE_URL);
   await db.execute(
-    `INSERT INTO episode_groups (id, parent_group_id, content, display_order, group_type, updated_at, deleted_at)
-     VALUES (?, ?, ?, ?, ?, ?, NULL)`,
+    `INSERT INTO episode_groups (id, parent_group_id, content, display_order, group_type, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
     [id, parentId, JSON.stringify({ name }), displayOrder, groupType, now]
   );
   return id;
@@ -46,8 +46,8 @@ export async function insertEpisode(params: {
 
   const id = generateId();
   await db.execute(
-    `INSERT INTO episodes (id, episode_group_id, content, updated_at, deleted_at)
-     VALUES (?, ?, ?, ?, NULL)`,
+    `INSERT INTO episodes (id, episode_group_id, content, updated_at)
+     VALUES (?, ?, ?, ?)`,
     [
       id,
       episodeGroupId,
@@ -112,8 +112,8 @@ export async function insertSubtitleLine(params: {
   const now = new Date().toISOString();
 
   await db.execute(
-    `INSERT INTO subtitle_lines (id, episode_id, sequence_number, content, updated_at, deleted_at)
-     VALUES (?, ?, ?, ?, ?, NULL)`,
+    `INSERT INTO subtitle_lines (id, episode_id, sequence_number, content, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
     [
       id,
       episodeId,
@@ -142,7 +142,6 @@ export async function getSentenceCards(subtitleLineId: string): Promise<Sentence
     content: string;
     status: 'active' | 'suspended' | 'cache';
     updated_at: string;
-    deleted_at: string | null;
   };
 
   function mapRowToSentenceCard(row: SentenceCardRow): SentenceCard {
@@ -207,8 +206,8 @@ export async function insertSentenceCard(params: {
     createdAt,
   });
   await db.execute(
-    `INSERT INTO sentence_cards (id, subtitle_line_id, content, status, updated_at, deleted_at)
-     VALUES (?, ?, ?, ?, ?, NULL)`,
+    `INSERT INTO sentence_cards (id, subtitle_line_id, content, status, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
     [id, subtitleLineId, content, status, createdAt]
   );
   return id;

--- a/src/lib/domain/entities/episode.ts
+++ b/src/lib/domain/entities/episode.ts
@@ -13,5 +13,4 @@ export type Episode = {
   readonly updatedAt: Date;
   readonly createdAt: Date;
   readonly sentenceCardCount: number;
-  readonly deletedAt?: string | null;
 };

--- a/src/lib/infrastructure/mocks/plugin-sql.ts
+++ b/src/lib/infrastructure/mocks/plugin-sql.ts
@@ -117,31 +117,27 @@ CREATE TABLE episode_groups (
     content TEXT NOT NULL,
     display_order INTEGER NOT NULL,
     group_type TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    deleted_at TEXT DEFAULT NULL
+    updated_at TEXT NOT NULL
 );
 CREATE TABLE episodes (
     id TEXT PRIMARY KEY,
     episode_group_id TEXT NOT NULL,
     content TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    deleted_at TEXT DEFAULT NULL
+    updated_at TEXT NOT NULL
 );
 CREATE TABLE subtitle_lines (
     id TEXT PRIMARY KEY,
     episode_id TEXT NOT NULL,
     sequence_number INTEGER NOT NULL,
     content TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    deleted_at TEXT DEFAULT NULL
+    updated_at TEXT NOT NULL
 );
 CREATE TABLE sentence_cards (
     id TEXT PRIMARY KEY,
     subtitle_line_id TEXT NOT NULL,
     content TEXT NOT NULL,
     status TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    deleted_at TEXT DEFAULT NULL
+    updated_at TEXT NOT NULL
 );
 `;
 

--- a/src/lib/infrastructure/repositories/sentenceCardRepository.ts
+++ b/src/lib/infrastructure/repositories/sentenceCardRepository.ts
@@ -9,7 +9,6 @@ type SentenceCardRow = {
   content: string;
   status: SentenceCardStatus;
   updated_at: string;
-  deleted_at: string | null;
 };
 
 type SentenceCardContent = {
@@ -74,8 +73,8 @@ export const sentenceCardRepository = {
   //     createdAt: now,
   //   });
   //   await db.execute(
-  //     `INSERT INTO sentence_cards (id, subtitle_line_id, content, status, updated_at, deleted_at)
-  //     VALUES (?, ?, ?, ?, ?, NULL)`,
+  //     `INSERT INTO sentence_cards (id, subtitle_line_id, content, status, updated_at)
+  //     VALUES (?, ?, ?, ?, ?)`,
   //     [id, params.subtitleLineId, content, params.status, now]
   //   );
 
@@ -135,13 +134,13 @@ export const sentenceCardRepository = {
           coreMeaning: item.coreMeaning,
           createdAt: now,
         }).replace(/'/g, "''");
-        return `('${item.id}', '${subtitleLineId.replace(/'/g, "''")}', '${content}', 'cache', '${now}', NULL)`;
+        return `('${item.id}', '${subtitleLineId.replace(/'/g, "''")}', '${content}', 'cache', '${now}')`;
       })
       .join(',');
 
     if (values.length === 0) return;
 
-    const query = `INSERT INTO sentence_cards (id, subtitle_line_id, content, status, updated_at, deleted_at) VALUES ${values}`;
+    const query = `INSERT INTO sentence_cards (id, subtitle_line_id, content, status, updated_at) VALUES ${values}`;
     await db.execute(query);
   },
 


### PR DESCRIPTION
This pull request removes the use of the `deleted_at` column from all episode-related tables, switching from a soft-delete approach to a hard-delete approach in both the schema and codebase. It updates documentation, SQL migrations, repository methods, and integration tests to reflect this change, simplifying data handling and queries.

### Database schema and migration changes

* Removed the `deleted_at` column from all tables (`episode_groups`, `episodes`, `subtitle_lines`, `sentence_cards`) in both the initial migration (`src-tauri/migrations/0001-initial-tables.sql`) and mock plugin SQL (`src/lib/infrastructure/mocks/plugin-sql.ts`). All related insert statements and queries were updated to exclude `deleted_at`. [[1]](diffhunk://#diff-8dfa1837146bd089fec46e5d3e3a551480e33e7148ff5b0b48772696dfcbcb24L7-R27) [[2]](diffhunk://#diff-4d2a42173681753e284e9d9751ea1cf1a709fd9692fae0b0d48e39957dd8aaeeL120-R140)
* Updated integration test database helpers to remove `deleted_at` from table definitions and queries. [[1]](diffhunk://#diff-f21aee2fa997330d5ad0084e747095ca1b2f912dc21fb5dc128bc1c30d2e1e6bL30-R31) [[2]](diffhunk://#diff-f21aee2fa997330d5ad0084e747095ca1b2f912dc21fb5dc128bc1c30d2e1e6bL49-R50) [[3]](diffhunk://#diff-f21aee2fa997330d5ad0084e747095ca1b2f912dc21fb5dc128bc1c30d2e1e6bL115-R116) [[4]](diffhunk://#diff-f21aee2fa997330d5ad0084e747095ca1b2f912dc21fb5dc128bc1c30d2e1e6bL145) [[5]](diffhunk://#diff-f21aee2fa997330d5ad0084e747095ca1b2f912dc21fb5dc128bc1c30d2e1e6bL210-R210)

### Repository and data access changes

* Updated `episodeGroupRepository` methods to remove all references to `deleted_at`, including query filters and insert/update logic. Now, groups are retrieved and updated without checking for soft-deleted status. [[1]](diffhunk://#diff-1a78140064a8e8bedf8b9a4cd21dd6c3f012d3764daab5b419eb4d49be79d4e7L13) [[2]](diffhunk://#diff-1a78140064a8e8bedf8b9a4cd21dd6c3f012d3764daab5b419eb4d49be79d4e7L57-R56) [[3]](diffhunk://#diff-1a78140064a8e8bedf8b9a4cd21dd6c3f012d3764daab5b419eb4d49be79d4e7L78-R79) [[4]](diffhunk://#diff-1a78140064a8e8bedf8b9a4cd21dd6c3f012d3764daab5b419eb4d49be79d4e7L107-R99) [[5]](diffhunk://#diff-1a78140064a8e8bedf8b9a4cd21dd6c3f012d3764daab5b419eb4d49be79d4e7L132-R124) [[6]](diffhunk://#diff-1a78140064a8e8bedf8b9a4cd21dd6c3f012d3764daab5b419eb4d49be79d4e7L145-R137) [[7]](diffhunk://#diff-1a78140064a8e8bedf8b9a4cd21dd6c3f012d3764daab5b419eb4d49be79d4e7L162-R158)

### Integration test changes

* Removed `deleted_at` from test data types and queries, and updated tests to expect hard-deletion behavior (e.g., deleted groups no longer appear in results). [[1]](diffhunk://#diff-b949347c02834a807bdf1af5d319dad7ebc01402f9d0e77f4449a657020786ceL36-L52) [[2]](diffhunk://#diff-b949347c02834a807bdf1af5d319dad7ebc01402f9d0e77f4449a657020786ceL196) [[3]](diffhunk://#diff-b949347c02834a807bdf1af5d319dad7ebc01402f9d0e77f4449a657020786ceL258-R253) [[4]](diffhunk://#diff-b949347c02834a807bdf1af5d319dad7ebc01402f9d0e77f4449a657020786ceL390-R383) [[5]](diffhunk://#diff-b949347c02834a807bdf1af5d319dad7ebc01402f9d0e77f4449a657020786ceL416)

### Documentation updates

* Updated technical specifications (`doc/technical_specifications.md`) and agent documentation (`src/AGENTS.md`) to remove references to `deleted_at` and soft-delete semantics, reflecting the new hard-delete approach. [[1]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L209-R209) [[2]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L224-L247) [[3]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L267) [[4]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L278) [[5]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L290-R285) [[6]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L304) [[7]](diffhunk://#diff-3362030dfe232705631df76d745905dabbe350cde1c448e0f6ccbaa1eeb1ef9cL134-R138)

### Domain model changes

* Removed the `deletedAt` property from the `Episode` entity definition, ensuring domain models align with the new schema.