### PR TITLE
All content columns from TEXT to JSONB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ Kotonoha is a desktop application that helps language learners transform audio/v
 - Frontend guidelines: Testing, browser-mode, dependencies, and coding style. See [src/AGENTS.md](src/AGENTS.md) for details.
 - Layered architecture: Four-layer structure (Presentation → Application → Infrastructure, with shared Domain). See [src/AGENTS.md](src/AGENTS.md) for details.
 - Key Tauri commands: LLM, Stronghold, Audio, Download, TTS, YouTube, Language Detection. See [src-tauri/AGENTS.md](src-tauri/AGENTS.md) for details.
-- Database overview: Tables for episode_groups, episodes, dialogues, sentence_cards. See [src-tauri/migrations/001-initial-tables.sql](src-tauri/migrations/001-initial-tables.sql) for details.
+- Database overview: Tables for episode_groups, episodes, subtitle_lines, sentence_cards. See [src-tauri/migrations/0001-initial-tables.sql](src-tauri/migrations/0001-initial-tables.sql) for details.
+- JSONB content policy: Store entity data in JSONB using camelCase keys that match TypeScript entity definitions.
 - File & media storage policy: Media stored under Tauri AppLocalData in media/{UUID}/. See [src/AGENTS.md](src/AGENTS.md) for details.
 - Data & state strategy: Avoid long-lived caches; fetch from DB via repositories. See [src/AGENTS.md](src/AGENTS.md) for details.
 - Security notes: API keys via Tauri Stronghold. See [src-tauri/AGENTS.md](src-tauri/AGENTS.md) for details.

--- a/doc/technical_specifications.md
+++ b/doc/technical_specifications.md
@@ -207,7 +207,8 @@ Infrastructure が Domain に依存する方向になっているが、Clean Arc
 
 - `id` は UUID 文字列（TEXT）。
 - `updated_at` は ISO 8601 文字列。INSERT 時に `updated_at` を現在時刻で設定する。
-- `content` カラムに JSON 文字列で可変フィールドを格納し、テーブルスキーマ変更を最小化する。
+- `content` カラムに JSONB で可変フィールドを格納し、テーブルスキーマ変更を最小化する。
+  - `content` 内のプロパティ名は TypeScript 側のエンティティ定義に合わせて camelCase で統一する。
 - 外部キー制約は付与しない（論理的なリレーションは維持）。
 
 ### ER図 (Mermaid)
@@ -219,26 +220,26 @@ erDiagram
         TEXT parent_group_id
         INTEGER display_order
         TEXT group_type
-        TEXT content
+        JSONB content
         TEXT updated_at
     }
     EPISODES {
         TEXT id PK
         TEXT episode_group_id
-        TEXT content
+        JSONB content
         TEXT updated_at
     }
     SUBTITLE_LINES {
         TEXT id PK
         TEXT episode_id
         INTEGER sequence_number
-        TEXT content
+        JSONB content
         TEXT updated_at
     }
     SENTENCE_CARDS {
         TEXT id PK
         TEXT subtitle_line_id
-        TEXT content
+        JSONB content
         TEXT status
         TEXT updated_at
     }
@@ -256,7 +257,7 @@ erDiagram
 |-------------------|---------|----------|-----------------------------------------------------|
 | `id`              | TEXT    |          | UUID (PK)                                           |
 | `parent_group_id` | TEXT    | ●        | 親グループID（NULL でルート扱い）                  |
-| `content`         | TEXT    |          | JSON 文字列。`{ name }` を保持                      |
+| `content`         | JSONB   |          | JSONB。エンティティの内容を保持 |
 | `display_order`   | INTEGER |          | 表示順序                                            |
 | `group_type`      | TEXT    |          | `album` (エピソード格納可) / `folder` (サブグループ専用) |
 | `updated_at`      | TEXT    |          | 最終更新時刻 (ISO 8601)                             |
@@ -268,7 +269,7 @@ erDiagram
 |----------------------|------|----------|------------------------------------------------------------------------|
 | `id`                 | TEXT |          | UUID (PK)                                                             |
 | `episode_group_id`   | TEXT |          | 論理的に `episode_groups.id` を参照                                   |
-| `content`            | TEXT |          | JSON 文字列。`{ title, mediaPath, learningLanguage, explanationLanguage }` |
+| `content`            | JSONB |          | JSONB。エンティティの内容を保持 |
 | `updated_at`         | TEXT |          | 最終更新時刻 (ISO 8601)                                               |
 
 ### 2.3. `subtitle_lines` テーブル（旧 `dialogues`）
@@ -279,7 +280,7 @@ erDiagram
 | `id`                | TEXT    |          | UUID (PK)                                                                            |
 | `episode_id`        | TEXT    |          | 論理的に `episodes.id` を参照                                                       |
 | `sequence_number`   | INTEGER |          | セリフ順。startTimeMs 昇順で 1 始まり                                               |
-| `content`           | TEXT    |          | JSON 文字列。`{ startTimeMs, endTimeMs, originalText, correctedText, translation, explanation, sentence, hidden }` |
+| `content`           | JSONB   |          | JSONB。エンティティの内容を保持 |
 | `updated_at`        | TEXT    |          | 最終更新時刻 (ISO 8601)                                                              |
 
 `hidden` は論理的な非表示フラグで、削除とは別に管理する。
@@ -291,7 +292,7 @@ Sentence Mining で生成されたカードを管理する。
 |---------------------|------|----------|---------------------------------------------------------------------------------------|
 | `id`                | TEXT |          | UUID (PK)                                                                            |
 | `subtitle_line_id`  | TEXT |          | 論理的に `subtitle_lines.id` を参照                                                 |
-| `content`           | TEXT |          | JSON 文字列。`{ partOfSpeech, expression, sentence, contextualDefinition, coreMeaning, createdAt }` |
+| `content`           | JSONB |          | JSONB。エンティティの内容を保持 |
 | `status`            | TEXT |          | `active` / `suspended` / `cache` などの状態                                          |
 | `updated_at`        | TEXT |          | 最終更新時刻 (ISO 8601)                                                              |
 

--- a/src-tauri/migrations/0001-initial-tables.sql
+++ b/src-tauri/migrations/0001-initial-tables.sql
@@ -1,7 +1,7 @@
 CREATE TABLE episode_groups (
     id TEXT PRIMARY KEY,
     parent_group_id TEXT,
-    content TEXT NOT NULL,
+    content JSONB NOT NULL,
     display_order INTEGER NOT NULL,
     group_type TEXT NOT NULL,
     updated_at TEXT NOT NULL
@@ -9,20 +9,20 @@ CREATE TABLE episode_groups (
 CREATE TABLE episodes (
     id TEXT PRIMARY KEY,
     episode_group_id TEXT NOT NULL,
-    content TEXT NOT NULL,
+    content JSONB NOT NULL,
     updated_at TEXT NOT NULL
 );
 CREATE TABLE subtitle_lines (
     id TEXT PRIMARY KEY,
     episode_id TEXT NOT NULL,
     sequence_number INTEGER NOT NULL,
-    content TEXT NOT NULL,
+    content JSONB NOT NULL,
     updated_at TEXT NOT NULL
 );
 CREATE TABLE sentence_cards (
     id TEXT PRIMARY KEY,
     subtitle_line_id TEXT NOT NULL,
-    content TEXT NOT NULL,
+    content JSONB NOT NULL,
     status TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );

--- a/src/integration-tests/episode-group.browser.test.ts
+++ b/src/integration-tests/episode-group.browser.test.ts
@@ -404,9 +404,9 @@ test('interaction error: shows error when deleting group fails', async () => {
     await expect.element(page.getByText('Failed to delete group.')).toBeInTheDocument();
     await expect.element(page.getByRole('button', { name: 'Yes, delete' })).not.toBeInTheDocument();
 
-  const groups = await selectAllGroups();
-  expect(groups).toHaveLength(1);
-  expect(await countEpisodes()).toBe(1);
+    const groups = await selectAllGroups();
+    expect(groups).toHaveLength(1);
+    expect(await countEpisodes()).toBe(1);
 
     await page.screenshot();
   } finally {

--- a/src/integration-tests/lib/database.ts
+++ b/src/integration-tests/lib/database.ts
@@ -34,11 +34,11 @@ export async function insertEpisodeGroup(params: {
       parentId,
       JSON.stringify({
         id,
-        parent_group_id: parentId,
+        parentId,
         name,
-        display_order: displayOrder,
-        group_type: groupType,
-        updated_at: now,
+        displayOrder,
+        groupType,
+        updatedAt: now,
       }),
       displayOrder,
       groupType,
@@ -67,14 +67,14 @@ export async function insertEpisode(params: {
       episodeGroupId,
       JSON.stringify({
         id,
-        episode_group_id: episodeGroupId,
+        episodeGroupId,
         title,
-        media_path: mediaPath || `media/${id}/full.mp3`,
-        learning_language: 'ja',
-        explanation_language: 'en',
-        display_order: displayOrder,
-        created_at: now,
-        updated_at: now,
+        mediaPath: mediaPath || `media/${id}/full.mp3`,
+        learningLanguage: 'ja',
+        explanationLanguage: 'en',
+        displayOrder,
+        createdAt: now,
+        updatedAt: now,
       }),
       now,
     ]
@@ -138,17 +138,17 @@ export async function insertSubtitleLine(params: {
       nextSequence,
       JSON.stringify({
         id,
-        episode_id: episodeId,
-        sequence_number: nextSequence,
-        start_time_ms: startTimeMs,
-        end_time_ms: endTimeMs,
-        original_text: originalText,
-        corrected_text: correctedText,
+        episodeId,
+        sequenceNumber: nextSequence,
+        startTimeMs,
+        endTimeMs,
+        originalText,
+        correctedText,
         translation,
         explanation,
         sentence,
         hidden,
-        updated_at: now,
+        updatedAt: now,
       }),
       now,
     ]
@@ -169,24 +169,24 @@ export async function getSentenceCards(subtitleLineId: string): Promise<Sentence
   function mapRowToSentenceCard(row: SentenceCardRow): SentenceCard {
     const content = JSON.parse(row.content) as {
       id?: string;
-      subtitle_line_id?: string;
-      part_of_speech?: string;
+      subtitleLineId?: string;
+      partOfSpeech?: string;
       expression?: string;
       sentence?: string;
-      contextual_definition?: string;
-      core_meaning?: string;
+      contextualDefinition?: string;
+      coreMeaning?: string;
       status?: SentenceCardRow['status'];
-      created_at?: string;
+      createdAt?: string;
     };
-    const createdAt = content.created_at ?? row.updated_at;
+    const createdAt = content.createdAt ?? row.updated_at;
     return {
       id: content.id ?? '',
-      subtitleLineId: content.subtitle_line_id ?? '',
-      partOfSpeech: content.part_of_speech ?? '',
+      subtitleLineId: content.subtitleLineId ?? '',
+      partOfSpeech: content.partOfSpeech ?? '',
       expression: content.expression ?? '',
       sentence: content.sentence ?? '',
-      contextualDefinition: content.contextual_definition ?? '',
-      coreMeaning: content.core_meaning ?? '',
+      contextualDefinition: content.contextualDefinition ?? '',
+      coreMeaning: content.coreMeaning ?? '',
       status: content.status ?? 'active',
       createdAt: new Date(createdAt),
     };
@@ -224,15 +224,15 @@ export async function insertSentenceCard(params: {
   const id = generateId();
   const content = JSON.stringify({
     id,
-    subtitle_line_id: subtitleLineId,
-    part_of_speech: partOfSpeech,
+    subtitleLineId,
+    partOfSpeech,
     expression,
     sentence,
-    contextual_definition: contextualDefinition,
-    core_meaning: coreMeaning,
+    contextualDefinition,
+    coreMeaning,
     status,
-    created_at: createdAt,
-    updated_at: createdAt,
+    createdAt,
+    updatedAt: createdAt,
   });
   await db.execute(
     `INSERT INTO sentence_cards (id, subtitle_line_id, content, status, updated_at)

--- a/src/lib/application/usecases/updateEpisodeGroupsOrder.ts
+++ b/src/lib/application/usecases/updateEpisodeGroupsOrder.ts
@@ -8,7 +8,7 @@ import { episodeGroupRepository } from '$lib/infrastructure/repositories/episode
 export async function updateEpisodeGroupsOrder(groups: readonly EpisodeGroup[]): Promise<void> {
   const groupsWithOrder = groups.map((group, index) => ({
     id: group.id,
-    display_order: index,
+    displayOrder: index,
   }));
   await episodeGroupRepository.updateOrders(groupsWithOrder);
 }

--- a/src/lib/application/usecases/updateEpisodesOrder.ts
+++ b/src/lib/application/usecases/updateEpisodesOrder.ts
@@ -8,7 +8,7 @@ import { episodeRepository } from '$lib/infrastructure/repositories/episodeRepos
 export async function updateEpisodesOrder(episodes: readonly Episode[]): Promise<void> {
   const episodesWithOrder = episodes.map((episode, index) => ({
     id: episode.id,
-    display_order: index,
+    displayOrder: index,
   }));
   await episodeRepository.updateOrders(episodesWithOrder);
 }

--- a/src/lib/infrastructure/mocks/plugin-sql.ts
+++ b/src/lib/infrastructure/mocks/plugin-sql.ts
@@ -114,7 +114,7 @@ const INITIAL_SCHEMA = `
 CREATE TABLE episode_groups (
     id TEXT PRIMARY KEY,
     parent_group_id TEXT,
-    content TEXT NOT NULL,
+    content JSONB NOT NULL,
     display_order INTEGER NOT NULL,
     group_type TEXT NOT NULL,
     updated_at TEXT NOT NULL
@@ -122,20 +122,20 @@ CREATE TABLE episode_groups (
 CREATE TABLE episodes (
     id TEXT PRIMARY KEY,
     episode_group_id TEXT NOT NULL,
-    content TEXT NOT NULL,
+    content JSONB NOT NULL,
     updated_at TEXT NOT NULL
 );
 CREATE TABLE subtitle_lines (
     id TEXT PRIMARY KEY,
     episode_id TEXT NOT NULL,
     sequence_number INTEGER NOT NULL,
-    content TEXT NOT NULL,
+    content JSONB NOT NULL,
     updated_at TEXT NOT NULL
 );
 CREATE TABLE sentence_cards (
     id TEXT PRIMARY KEY,
     subtitle_line_id TEXT NOT NULL,
-    content TEXT NOT NULL,
+    content JSONB NOT NULL,
     status TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );

--- a/src/lib/infrastructure/repositories/subtitleLineRepository.ts
+++ b/src/lib/infrastructure/repositories/subtitleLineRepository.ts
@@ -11,65 +11,21 @@ type SubtitleLineRow = {
   updated_at: string;
 };
 
-type SubtitleLineContent = {
-  id?: string;
-  episode_id?: string;
-  sequence_number?: number;
-  start_time_ms?: number;
-  end_time_ms?: number | null;
-  original_text?: string;
-  corrected_text?: string | null;
-  translation?: string | null;
-  explanation?: string | null;
-  sentence?: string | null;
-  hidden?: boolean;
-  updated_at?: string;
+type SubtitleLineContent = SubtitleLine & {
+  updatedAt: string;
 };
 
-function parseSubtitleLineContent(raw: string): SubtitleLineContent | null {
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === 'object') {
-      return parsed as SubtitleLineContent;
-    }
-  } catch {
-    // ignore parse errors
+function parseSubtitleLineContent(raw: string): SubtitleLineContent {
+  const parsed = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Invalid subtitle line content: root');
   }
-  return null;
-}
-
-function normalizeSubtitleLineContent(content: SubtitleLineContent): Required<SubtitleLineContent> {
-  return {
-    id: typeof content.id === 'string' ? content.id : '',
-    episode_id: typeof content.episode_id === 'string' ? content.episode_id : '',
-    sequence_number: typeof content.sequence_number === 'number' ? content.sequence_number : 0,
-    start_time_ms: typeof content.start_time_ms === 'number' ? content.start_time_ms : 0,
-    end_time_ms: typeof content.end_time_ms === 'number' ? content.end_time_ms : null,
-    original_text: typeof content.original_text === 'string' ? content.original_text : '',
-    corrected_text: typeof content.corrected_text === 'string' ? content.corrected_text : null,
-    translation: typeof content.translation === 'string' ? content.translation : null,
-    explanation: typeof content.explanation === 'string' ? content.explanation : null,
-    sentence: typeof content.sentence === 'string' ? content.sentence : null,
-    hidden: typeof content.hidden === 'boolean' ? content.hidden : false,
-    updated_at: typeof content.updated_at === 'string' ? content.updated_at : '',
-  };
+  return parsed as SubtitleLineContent;
 }
 
 function mapRowToSubtitleLine(row: SubtitleLineRow): SubtitleLine {
-  const content = normalizeSubtitleLineContent(parseSubtitleLineContent(row.content) ?? {});
-  return {
-    id: content.id,
-    episodeId: content.episode_id,
-    sequenceNumber: content.sequence_number,
-    startTimeMs: content.start_time_ms,
-    endTimeMs: content.end_time_ms,
-    originalText: content.original_text,
-    correctedText: content.corrected_text,
-    translation: content.translation,
-    explanation: content.explanation,
-    sentence: content.sentence,
-    hidden: content.hidden,
-  };
+  const content = parseSubtitleLineContent(row.content);
+  return content;
 }
 
 function escapeSqlString(value: string): string {
@@ -78,7 +34,7 @@ function escapeSqlString(value: string): string {
 
 async function updateSubtitleLineContent(
   subtitleLineId: string,
-  updater: (content: Required<SubtitleLineContent>) => Required<SubtitleLineContent>
+  updater: (content: SubtitleLineContent) => SubtitleLineContent
 ): Promise<void> {
   const db = new Database(await getDatabasePath());
   const rows = await db.select<{ content: string }[]>(
@@ -87,15 +43,11 @@ async function updateSubtitleLineContent(
   );
   if (rows.length === 0) return;
 
-  const parsed = parseSubtitleLineContent(rows[0].content);
-  if (!parsed) {
-    throw new Error(`Failed to parse subtitle line content for id: ${subtitleLineId}`);
-  }
-  const currentContent = normalizeSubtitleLineContent(parsed);
+  const currentContent = parseSubtitleLineContent(rows[0].content);
   const updatedContent = updater(currentContent);
   const now = new Date().toISOString();
   await db.execute('UPDATE subtitle_lines SET content = ?, updated_at = ? WHERE id = ?', [
-    JSON.stringify({ ...updatedContent, updated_at: now }),
+    JSON.stringify({ ...updatedContent, updatedAt: now }),
     now,
     subtitleLineId,
   ]);
@@ -129,20 +81,20 @@ export const subtitleLineRepository = {
     const values = sortedSubtitleLines
       .map((d, index) => {
         const id = uuidV4();
-        const content = normalizeSubtitleLineContent({
+        const content: SubtitleLineContent = {
           id,
-          episode_id: episodeId,
-          sequence_number: index + 1,
-          start_time_ms: d.startTimeMs,
-          end_time_ms: d.endTimeMs,
-          original_text: d.originalText,
-          corrected_text: null,
+          episodeId,
+          sequenceNumber: index + 1,
+          startTimeMs: d.startTimeMs,
+          endTimeMs: d.endTimeMs,
+          originalText: d.originalText,
+          correctedText: null,
           translation: null,
           explanation: null,
           sentence: null,
           hidden: false,
-          updated_at: now,
-        });
+          updatedAt: now,
+        };
         return `('${id}', '${escapeSqlString(episodeId)}', ${index + 1}, '${escapeSqlString(
           JSON.stringify(content)
         )}', '${now}')`;
@@ -180,7 +132,7 @@ export const subtitleLineRepository = {
   ): Promise<void> {
     await updateSubtitleLineContent(subtitleLineId, (content) => ({
       ...content,
-      corrected_text: correctedText,
+      correctedText,
     }));
   },
 


### PR DESCRIPTION
This pull request introduces a comprehensive update to the data storage strategy, focusing on unifying the structure and naming conventions of JSON content stored in the database. The main changes include migrating all entity `content` columns from `TEXT` to `JSONB`, enforcing camelCase property names (aligned with TypeScript definitions), and ensuring that entity content includes all relevant fields, such as IDs and timestamps. These changes affect both documentation and application/database code, improving consistency, type safety, and future extensibility.

**Database schema and storage changes:**

* Migrated all `content` columns in `episode_groups`, `episodes`, `subtitle_lines`, and `sentence_cards` tables from `TEXT` to `JSONB`, both in the actual migration (`src-tauri/migrations/0001-initial-tables.sql`) and in the mock schema (`src/lib/infrastructure/mocks/plugin-sql.ts`). [[1]](diffhunk://#diff-8dfa1837146bd089fec46e5d3e3a551480e33e7148ff5b0b48772696dfcbcb24L4-R25) [[2]](diffhunk://#diff-4d2a42173681753e284e9d9751ea1cf1a709fd9692fae0b0d48e39957dd8aaeeL117-R138)
* Updated ER diagrams and documentation to reflect the use of `JSONB` for entity content, and clarified that property names within `content` must use camelCase to match TypeScript entity definitions. [[1]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L210-R211) [[2]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L222-R242) [[3]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L259-R260) [[4]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L271-R272) [[5]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L282-R283) [[6]](diffhunk://#diff-7b252844803a0f151dbd318deba7e15a9e50f4c23d4aac17570fa6aa1f3af049L294-R295)

**Entity content structure and naming conventions:**

* Standardized all entity `content` JSON to include camelCase property names and all relevant fields (such as `id`, `parentId`, `displayOrder`, `groupType`, `updatedAt`, etc.), both in integration tests and repository code. [[1]](diffhunk://#diff-f21aee2fa997330d5ad0084e747095ca1b2f912dc21fb5dc128bc1c30d2e1e6bL32-R46) [[2]](diffhunk://#diff-f21aee2fa997330d5ad0084e747095ca1b2f912dc21fb5dc128bc1c30d2e1e6bR69-R77) [[3]](diffhunk://#diff-f21aee2fa997330d5ad0084e747095ca1b2f912dc21fb5dc128bc1c30d2e1e6bR140-R151) [[4]](diffhunk://#diff-f21aee2fa997330d5ad0084e747095ca1b2f912dc21fb5dc128bc1c30d2e1e6bR226-R235) [[5]](diffhunk://#diff-1a78140064a8e8bedf8b9a4cd21dd6c3f012d3764daab5b419eb4d49be79d4e7L15-R34) [[6]](diffhunk://#diff-1a78140064a8e8bedf8b9a4cd21dd6c3f012d3764daab5b419eb4d49be79d4e7R69-R80)
* Updated documentation and code comments to require camelCase property names in `content` columns and to use `updatedAt` instead of `updated_at`. [[1]](diffhunk://#diff-76fc0a6c63535ec2a674fd04df42edba8195f8e33abac0f9b24ea059140ddba2L55-R57) [[2]](diffhunk://#diff-76fc0a6c63535ec2a674fd04df42edba8195f8e33abac0f9b24ea059140ddba2L100-R106) [[3]](diffhunk://#diff-76fc0a6c63535ec2a674fd04df42edba8195f8e33abac0f9b24ea059140ddba2L522-R546) [[4]](diffhunk://#diff-76fc0a6c63535ec2a674fd04df42edba8195f8e33abac0f9b24ea059140ddba2L728-R745) [[5]](diffhunk://#diff-76fc0a6c63535ec2a674fd04df42edba8195f8e33abac0f9b24ea059140ddba2L766-R768) [[6]](diffhunk://#diff-76fc0a6c63535ec2a674fd04df42edba8195f8e33abac0f9b24ea059140ddba2L786-R788) [[7]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L13-R14)

**Repository and use case updates:**

* Refactored repository mapping logic to use the new, more complete entity content structure (including IDs and camelCase fields), and updated the mapping of database rows to application entities accordingly. [[1]](diffhunk://#diff-1a78140064a8e8bedf8b9a4cd21dd6c3f012d3764daab5b419eb4d49be79d4e7L15-R34) [[2]](diffhunk://#diff-1a78140064a8e8bedf8b9a4cd21dd6c3f012d3764daab5b419eb4d49be79d4e7R69-R80) [[3]](diffhunk://#diff-f21aee2fa997330d5ad0084e747095ca1b2f912dc21fb5dc128bc1c30d2e1e6bR171-R190)
* Updated use cases to use camelCase property names (e.g., `displayOrder` instead of `display_order`) when updating orders for episode groups and episodes. [[1]](diffhunk://#diff-e5060863da4f7998a106de6e397a817bfca5c0a259cd7eb1e10d21067eea5c98L11-R11) [[2]](diffhunk://#diff-124015f8f16897ba245fa6991ffd0a7c80bacc7f0a2796c16515e0bfd20f496aL11-R11)

These changes establish a consistent, type-safe, and future-proof approach to storing and handling entity data across the application and database layers.